### PR TITLE
SONARMSBRU-28: allow analysis settings to be supplied in MSBuild projects

### DIFF
--- a/SonarQube.Common/FilePropertiesProvider.cs
+++ b/SonarQube.Common/FilePropertiesProvider.cs
@@ -90,11 +90,18 @@ namespace SonarQube.Common
             this.properties = new Dictionary<string, string>(PropertyKeyComparer);
             string allText = File.ReadAllText(fullPath);
 
+            //TODO: this expression only works for single-line values
+
             // Regular expression pattern: we're looking for matches that:
             // * start at the beginning of a line
             // * start with a character or number
-            // * consist of string of characters, numbers or "." without whitespace, followed by "=", followed by another string of characters up to the end of the line
-            string pattern = @"^(?<key>[\w|\.]+)=(?<value>[^\r\n]*)";
+            // * are in the form [key]=[value],
+            // * where [key] can  
+            //   - starts with an alpanumeric character.
+            //   - can be followed by any number of alphanumeric characters or .
+            //   - whitespace is not allowed
+            // * [value] can contain anything
+            string pattern = @"^(?<key>\w[\w\d\.-]*)=(?<value>[^\r\n]*)";
 
             foreach (Match match in Regex.Matches(allText, pattern, RegexOptions.Multiline))
             {

--- a/SonarQube.Common/ProjectInfo/ProjectInfo.cs
+++ b/SonarQube.Common/ProjectInfo/ProjectInfo.cs
@@ -72,6 +72,12 @@ namespace SonarQube.Common
         /// </summary>
         public List<AnalysisResult> AnalysisResults { get; set; }
 
+
+        /// <summary>
+        /// List of additional analysis settings
+        /// </summary>
+        public List<AnalysisSetting> AnalysisSettings { get; set; }
+
         #endregion
 
         #region Serialization

--- a/SonarQube.Common/ProjectInfo/ProjectInfoExtensions.cs
+++ b/SonarQube.Common/ProjectInfo/ProjectInfoExtensions.cs
@@ -50,6 +50,26 @@ namespace SonarQube.Common
         }
 
         /// <summary>
+        /// Attempts to find and return the analysis setting with the specified id
+        /// </summary>
+        /// <returns>True if the setting was found, otherwise false</returns>
+        public static bool TryGetAnalysisSetting(this ProjectInfo projectInfo, string id, out AnalysisSetting result)
+        {
+            if (projectInfo == null)
+            {
+                throw new ArgumentNullException("projectInfo");
+            }
+
+            result = null;
+
+            if (projectInfo.AnalysisSettings != null)
+            {
+                result = projectInfo.AnalysisSettings.FirstOrDefault(ar => id.Equals(ar.Id, StringComparison.Ordinal));
+            }
+            return result != null;
+        }
+
+        /// <summary>
         /// Adds an analysis result of the specified type
         /// </summary>
         /// <remarks>The method does not check whether an analysis result with the same id already exists i.e. duplicate results are allowed</remarks>

--- a/SonarQube.MSBuild.Tasks/BuildTaskConstants.cs
+++ b/SonarQube.MSBuild.Tasks/BuildTaskConstants.cs
@@ -9,7 +9,24 @@ namespace SonarQube.MSBuild.Tasks
 {
     public static class BuildTaskConstants
     {
+        /// <summary>
+        /// Item name of the analysis result item type
+        /// </summary>
         public const string ResultItemName = "AnalysisResult";
+
+        /// <summary>
+        /// Name of the analysis result "id" metadata item
+        /// </summary>
         public const string ResultMetadataIdProperty = "Id";
+
+        /// <summary>
+        /// Item name of the analysis setting item type
+        /// </summary>
+        public const string ModuleSettingItemName = "SonarQubeSetting";
+
+        /// <summary>
+        /// Name of the analysis setting "value" metadata item
+        /// </summary>
+        public const string ModuleSettingValueMetadataName = "Value";
     }
 }

--- a/SonarQube.MSBuild.Tasks/Resources.Designer.cs
+++ b/SonarQube.MSBuild.Tasks/Resources.Designer.cs
@@ -161,5 +161,23 @@ namespace SonarQube.MSBuild.Tasks {
                 return ResourceManager.GetString("WPIF_ResolvingRelativePath", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analysis setting key &quot;{0}&quot; is invalid and will be ignored.
+        /// </summary>
+        internal static string WPIF_WARN_InvalidSettingKey {
+            get {
+                return ResourceManager.GetString("WPIF_WARN_InvalidSettingKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Analysis setting &quot;{0}&quot; does not have &quot;Value&quot; metadata and will be ignored.
+        /// </summary>
+        internal static string WPIF_WARN_MissingValueMetadata {
+            get {
+                return ResourceManager.GetString("WPIF_WARN_MissingValueMetadata", resourceCulture);
+            }
+        }
     }
 }

--- a/SonarQube.MSBuild.Tasks/Resources.resx
+++ b/SonarQube.MSBuild.Tasks/Resources.resx
@@ -154,4 +154,10 @@ Error: {1}</value>
   <data name="WPIF_ResolvingRelativePath" xml:space="preserve">
     <value>Attempting to resolve the file result path. Analysis type: {0}, path: {1}</value>
   </data>
+  <data name="WPIF_WARN_InvalidSettingKey" xml:space="preserve">
+    <value>Analysis setting key "{0}" is invalid and will be ignored</value>
+  </data>
+  <data name="WPIF_WARN_MissingValueMetadata" xml:space="preserve">
+    <value>Analysis setting "{0}" does not have "Value" metadata and will be ignored</value>
+  </data>
 </root>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -237,6 +237,7 @@
        IsTest="$(SonarQubeTestProject)"
        IsExcluded="$(SonarQubeExclude)"
        AnalysisResults="@(AnalysisResults)"
+       AnalysisSettings="@(SonarQubeSetting)"
        OutputFolder="$(ProjectSpecificDir)" />
   </Target>
 

--- a/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -31,7 +31,7 @@ namespace SonarQube.MSBuild.Tasks
         /// Can be followed by any number of alphanumeric characters or .
         /// Whitespace is not allowed
         /// </remarks>
-        private static readonly Regex ValidSettingKeyRegEx = new Regex(@"^\w[\w\d\.]*$", RegexOptions.Compiled);
+        private static readonly Regex ValidSettingKeyRegEx = new Regex(@"^\w[\w\d\.-]*$", RegexOptions.Compiled);
 
         #region Input properties
 

--- a/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -12,6 +12,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SonarQube.MSBuild.Tasks
 {
@@ -20,6 +22,17 @@ namespace SonarQube.MSBuild.Tasks
     /// </summary>
     public class WriteProjectInfoFile : Task
     {
+        /// <summary>
+        /// Regular expression to validate setting ids.
+        /// </summary>
+        /// <remarks>
+        /// Validation rules:
+        /// Must start with an alpanumeric character.
+        /// Can be followed by any number of alphanumeric characters or .
+        /// Whitespace is not allowed
+        /// </remarks>
+        private static readonly Regex ValidSettingKeyRegEx = new Regex(@"^\w[\w\d\.]*$", RegexOptions.Compiled);
+
         #region Input properties
 
         // TODO: we can get this from this.BuildEngine.ProjectFileOfTaskNode; we don't need the caller to supply it. Same for the full path
@@ -37,9 +50,10 @@ namespace SonarQube.MSBuild.Tasks
         [Required]
         public bool IsExcluded { get; set; }
 
-
         [Required]
         public ITaskItem[] AnalysisResults { get; set; }
+
+        public ITaskItem[] AnalysisSettings { get; set; }
 
         /// <summary>
         /// The folder in which the file should be written
@@ -60,12 +74,12 @@ namespace SonarQube.MSBuild.Tasks
             pi.ProjectName = this.ProjectName;
             pi.FullPath = this.FullProjectPath;
 
-            // TODO: handle failures and missing values.
             Guid projectId;
             if (Guid.TryParse(this.ProjectGuid, out projectId))
             {
                 pi.ProjectGuid = projectId;
                 pi.AnalysisResults = TryCreateAnalysisResults(this.AnalysisResults);
+                pi.AnalysisSettings = TryCreateAnalysisSettings(this.AnalysisSettings);
 
                 string outputFileName = Path.Combine(this.OutputFolder, FileConstants.ProjectInfoFileName);
                 pi.Save(outputFileName);
@@ -140,6 +154,103 @@ namespace SonarQube.MSBuild.Tasks
                 };
             }
             return result;
+        }
+
+        /// <summary>
+        /// Attempts to convert the supplied task items into a list of <see cref="AnalysisSetting"/> objects
+        /// </summary>
+        private List<AnalysisSetting> TryCreateAnalysisSettings(ITaskItem[] resultItems)
+        {
+            List<AnalysisSetting> settings = new List<AnalysisSetting>();
+
+            if (resultItems != null)
+            {
+                foreach (ITaskItem resultItem in resultItems)
+                {
+                    AnalysisSetting result = TryCreateSettingFromItem(resultItem);
+                    if (result != null)
+                    {
+                        settings.Add(result);
+                    }
+                }
+            }
+            return settings;
+        }
+
+        /// <summary>
+        /// Attempts to create an <see cref="AnalysisSetting"/> from the supplied task item.
+        /// Returns null if the task item does not have the required metadata.
+        /// </summary>
+        private AnalysisSetting TryCreateSettingFromItem(ITaskItem taskItem)
+        {
+            Debug.Assert(taskItem != null, "Supplied task item should not be null");
+
+            AnalysisSetting setting = null;
+
+            string settingId;
+
+            if (TryGetSettingId(taskItem, out settingId))
+            {
+                // No validation for the value: can be anything, but the
+                // "Value" metadata item must exist
+                string settingValue;
+
+                if (TryGetSettingValue(taskItem, out settingValue))
+                {
+                    setting = new AnalysisSetting()
+                    {
+                        Id = settingId,
+                        Value = settingValue
+                    };
+                }
+            }
+            return setting;
+        }
+
+        /// <summary>
+        /// Attempts to extract the setting id from the supplied task item.
+        /// Logs warnings if the task item does not contain valid data.
+        /// </summary>
+        private bool TryGetSettingId(ITaskItem taskItem, out string settingId)
+        {
+            settingId = null;
+
+            string possibleKey = taskItem.ItemSpec;
+
+            bool isValid = ValidSettingKeyRegEx.IsMatch(possibleKey);
+            if (isValid)
+            {
+                settingId = possibleKey;
+            }
+            else
+            {
+                this.Log.LogWarning(Resources.WPIF_WARN_InvalidSettingKey, possibleKey);
+            }
+            return isValid;
+        }
+
+        /// <summary>
+        /// Attempts to return the value to use for the setting.
+        /// Logs warnings if the task item does not contain valid data.
+        /// </summary>
+        /// <remarks>The task should have a "Value" metadata item</remarks>
+        private bool TryGetSettingValue(ITaskItem taskItem, out string metadataValue)
+        {
+            bool success;
+
+            metadataValue  = taskItem.GetMetadata(BuildTaskConstants.ModuleSettingValueMetadataName);
+            Debug.Assert(metadataValue != null, "Not expecting the metadata value to be null even if the setting is missing");
+
+            if (metadataValue == string.Empty)
+            {
+                this.Log.LogWarning(Resources.WPIF_WARN_MissingValueMetadata, taskItem.ItemSpec);
+                success = false;
+            }
+            else
+            {
+                success = true;
+            }
+            return success;
         }
 
         #endregion

--- a/SonarRunner.Shim/PropertiesWriter.cs
+++ b/SonarRunner.Shim/PropertiesWriter.cs
@@ -145,6 +145,16 @@ namespace SonarRunner.Shim
             sb.AppendLine(string.Join(@",\" + Environment.NewLine, escapedFiles));
 
             sb.AppendLine();
+
+            if (project.AnalysisSettings != null && project.AnalysisSettings.Any())
+            {
+                foreach(AnalysisSetting setting in project.AnalysisSettings)
+                {
+                    sb.AppendFormat("{0}.{1}={2}", guid, setting.Id, Escape(setting.Value));
+                    sb.AppendLine();
+                }
+                sb.AppendLine();
+            }
         }
 
         #endregion

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/Infrastructure/DummyBuildEngine.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/Infrastructure/DummyBuildEngine.cs
@@ -111,11 +111,21 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
         /// <summary>
         /// Checks that at least one message exists that contains all of the specified strings.
         /// </summary>
-        public void AssertMessageExists(params string[] expected)
+        public void AssertSingleMessageExists(params string[] expected)
         {
             IEnumerable<BuildMessageEventArgs> matches = this.messages.Where(m => expected.All(e => m.Message.Contains(e)));
             Assert.AreNotEqual(0, matches.Count(), "No message contains the expected strings: {0}", string.Join(",", expected));
             Assert.AreEqual(1, matches.Count(), "More than one message contains the expected strings: {0}", string.Join(",", expected));
+        }
+
+        /// <summary>
+        /// Checks that at least one warning exists that contains all of the specified strings.
+        /// </summary>
+        public void AssertSingleWarningExists(params string[] expected)
+        {
+            IEnumerable<BuildWarningEventArgs> matches = this.warnings.Where(w => expected.All(e => w.Message.Contains(e)));
+            Assert.AreNotEqual(0, matches.Count(), "No warning contains the expected strings: {0}", string.Join(",", expected));
+            Assert.AreEqual(1, matches.Count(), "More than one warning contains the expected strings: {0}", string.Join(",", expected));
         }
 
         #endregion

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/IsTestFileByNameTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/IsTestFileByNameTests.cs
@@ -127,7 +127,7 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             Assert.IsTrue(result, "Expecting the task to succeed");
             Assert.IsTrue(task.IsTest, "Expecting the file to be recognised as a test");
 
-            dummyEngine.AssertMessageExists(IsTestFileByName.MaxConfigRetryPeriodInMilliseconds.ToString(), IsTestFileByName.DelayBetweenRetriesInMilliseconds.ToString());
+            dummyEngine.AssertSingleMessageExists(IsTestFileByName.MaxConfigRetryPeriodInMilliseconds.ToString(), IsTestFileByName.DelayBetweenRetriesInMilliseconds.ToString());
             dummyEngine.AssertNoErrors();
             dummyEngine.AssertNoWarnings();
         }
@@ -163,7 +163,7 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
 
             Assert.IsFalse(result, "Expecting the task to fail");
 
-            dummyEngine.AssertMessageExists(IsTestFileByName.MaxConfigRetryPeriodInMilliseconds.ToString(), IsTestFileByName.DelayBetweenRetriesInMilliseconds.ToString());
+            dummyEngine.AssertSingleMessageExists(IsTestFileByName.MaxConfigRetryPeriodInMilliseconds.ToString(), IsTestFileByName.DelayBetweenRetriesInMilliseconds.ToString());
             dummyEngine.AssertNoWarnings();
             dummyEngine.AssertSingleErrorExists();
         }

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
@@ -145,6 +145,7 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             resultInputs.Add(CreateAnalysisSettingTaskItem("valid.value.has.whitespace", "valid setting with whitespace"));
             resultInputs.Add(CreateAnalysisSettingTaskItem("X", "single character key"));
             resultInputs.Add(CreateAnalysisSettingTaskItem("Y...", "single character followed by periods"));
+            resultInputs.Add(CreateAnalysisSettingTaskItem("7B3B7244-5031-4D74-9BBD-3316E6B5E7D5.sonar.projectName", "guid followed by key"));
 
             task.AnalysisSettings = resultInputs.ToArray();
 
@@ -166,9 +167,9 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             AssertAnalysisSettingExists(createdProjectInfo, "valid.metadata.name.is.case.insensitive", "uppercase metadata name");
             AssertAnalysisSettingExists(createdProjectInfo, "X", "single character key");
             AssertAnalysisSettingExists(createdProjectInfo, "Y...", "single character followed by periods");
+            AssertAnalysisSettingExists(createdProjectInfo, "7B3B7244-5031-4D74-9BBD-3316E6B5E7D5.sonar.projectName", "guid followed by key");
 
-
-            AssertExpectedAnalysisSettingsCount(6, createdProjectInfo);
+            AssertExpectedAnalysisSettingsCount(7, createdProjectInfo);
         }
 
         [TestMethod]


### PR DESCRIPTION
* updated the targets file to pass a list of SonarQubeSetting items to the WriteProjectItemTask
* updated the WriteProjectItemTask to handle accept a list of TaskItems that it writes into the ProjectInfo.xml file.
* updated the PropertiesWriter to emit the settings from the ProjectInfo.xml file into the sonar-project.properties file

* added units tests for the task and properties writer
* added an integration test for the targets