### PR TITLE
SONARMSBRU-43 Set the temporary folder to '.sonarqube' within the CWD

### DIFF
--- a/SonarQube.Bootstrapper/BootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/BootstrapperSettings.cs
@@ -31,7 +31,7 @@ namespace SonarQube.Bootstrapper
                 BuildDirectory_TFS2015      // TeamBuild 2015 and later build directory
                };
 
-        private const string RelativePathToDownloadDir = @"sqtemp\bin";
+        private const string RelativePathToDownloadDir = @".sonarqube\bin";
 
 
         private Settings appConfig;

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.ImportBefore.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.ImportBefore.targets
@@ -1,37 +1,35 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- **************************************************************************** -->
-  <!-- Auto-import the targets if we are running under TeamBuild and the analysis config file exists -->
+  <!-- Compute the SonarQube analysis temporary directory -->
   <!-- **************************************************************************** -->
-  <PropertyGroup Condition="$(RunSonarQubeAnalysis) == '' ">
-    <TeamBuildDir>$(TF_BUILD_BUILDDIRECTORY)</TeamBuildDir>
-    <TeamBuildDir Condition=" $(TeamBuildDir) == '' ">$(AGENT_BUILDDIRECTORY)</TeamBuildDir>
+  <PropertyGroup Condition=" $(SonarQubeTempPath) == '' ">
+    <!-- TFS 2013 -->
+    <SonarQubeBuildDirectory>$(TF_BUILD_BUILDDIRECTORY)</SonarQubeBuildDirectory>
+    <!-- TFS 2015 -->
+    <SonarQubeBuildDirectory Condition=" $(SonarQubeBuildDirectory) == '' ">$(AGENT_BUILDDIRECTORY)</SonarQubeBuildDirectory>
+    <!-- Command line -->
+    <SonarQubeBuildDirectory Condition=" $(SonarQubeBuildDirectory) == '' ">$(MSBuildStartupDirectory)</SonarQubeBuildDirectory>
 
-    <AutoImportSonarQubeAnalysisTargets Condition=" $(TeamBuildDir) != '' AND Exists('$(TeamBuildDir)\sqtemp\conf\SonarQubeAnalysisConfig.xml') ">true</AutoImportSonarQubeAnalysisTargets>
+    <SonarQubeTempPath Condition=" $(SonarQubeBuildDirectory) != '' AND Exists('$(SonarQubeBuildDirectory)\.sonarqube\conf\SonarQubeAnalysisConfig.xml') ">$(SonarQubeBuildDirectory)\.sonarqube</SonarQubeTempPath>
 
-    <RunSonarQubeAnalysis>$(AutoImportSonarQubeAnalysisTargets)</RunSonarQubeAnalysis>
+    <AutoImportSonarQubeAnalysisTargets Condition=" $(SonarQubeTempPath) != '' ">true</AutoImportSonarQubeAnalysisTargets>
   </PropertyGroup>
 
   <!-- **************************************************************************** -->
   <!-- Compute the path to the targets if not specified -->
   <!-- **************************************************************************** -->
-  <!-- TFS 2013 -->
-  <PropertyGroup Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeTargetsPath) == '' AND $(TF_BUILD_BUILDDIRECTORY) != ''">
-    <SonarQubeTargetsPath>$(TF_BUILD_BUILDDIRECTORY)\sqtemp\bin\targets</SonarQubeTargetsPath>
-  </PropertyGroup>
-  <!-- TFS 2015 -->
-  <PropertyGroup Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeTargetsPath) == '' AND $(AGENT_BUILDDIRECTORY) != ''">
-    <SonarQubeTargetsPath>$(AGENT_BUILDDIRECTORY)\sqTemp\bin\targets</SonarQubeTargetsPath>
+  <PropertyGroup Condition=" $(SonarQubeTempPath) != '' AND $(SonarQubeTargetsPath) == '' ">
+    <SonarQubeTargetsPath>$(SonarQubeTempPath)\bin\targets</SonarQubeTargetsPath>
   </PropertyGroup>
 
   <!-- **************************************************************************** -->
   <!-- Import the analysis targets if appropriate -->
   <!-- **************************************************************************** -->
-  <PropertyGroup Condition="$(SonarQubeTargetsImported) != 'true' AND $(RunSonarQubeAnalysis) == 'true' ">
+  <PropertyGroup Condition=" $(SonarQubeTargetsPath) != '' AND $(SonarQubeTargetFilePath) == '' ">
     <SonarQubeTargetFilePath>$(SonarQubeTargetsPath)\SonarQube.Integration.targets</SonarQubeTargetFilePath>
   </PropertyGroup>
-  <Import Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeTargetsImported) != 'true' AND Exists('$(SonarQubeTargetFilePath)')" Project="$(SonarQubeTargetFilePath)" />
-
+  <Import Condition=" $(SonarQubeTargetsImported) != 'true' AND Exists('$(SonarQubeTargetFilePath)') " Project="$(SonarQubeTargetFilePath)" />
 
   <!-- **************************************************************************** -->
   <!-- Diagnostic/error-checking target
@@ -42,16 +40,15 @@
         
         Writes out diagnostic information to help with troubleshooting.  -->
   <!-- **************************************************************************** -->
-  <Target Name="SonarQubeImportBeforeInfo" Condition="$(RunSonarQubeAnalysis) == 'true' " BeforeTargets="CoreCompile">
+  <Target Name="SonarQubeImportBeforeInfo" Condition=" $(SonarQubeTempPath) != '' " BeforeTargets="CoreCompile">
 
     <PropertyGroup>
       <AnalysisTargetsFileFound Condition=" Exists('$(SonarQubeTargetFilePath)') " >true</AnalysisTargetsFileFound>
-      <ReportAnalysisTargetsError Condition=" $(RunSonarQubeAnalysis)=='true' AND $(AnalysisTargetsFileFound) != 'true'">true</ReportAnalysisTargetsError>
+      <ReportAnalysisTargetsError Condition=" $(AnalysisTargetsFileFound) != 'true'">true</ReportAnalysisTargetsError>
     </PropertyGroup>
 
     <!-- Diagnostic messages for troubleshooting -->
     <Message Importance="low" Text="SonarQube.Integration.ImportBefore.targets was loaded" />
-    <Message Importance="normal" Text="SonarQube analysis targets were automatically imported" Condition="$(AutoImportSonarQubeAnalysisTargets) == 'true' " />
     <Message Importance="low" Text="SonarQube analysis targets file found: $(AnalysisTargetsFileFound)" />
     <Message Importance="low" Text="SonarQube analysis targets imported: $(SonarQubeTargetsImported)" />
 

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -1,114 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!--
-      This file contains targets to integrate SonarQube and MSBuild.
-      
-      The targets will produce an output folder structure containing information required
-      by SonarQube.
-      
-      A subdirectory will be created for each MSBuild project. Information about the project 
-      will be written to a file called "ProjectInfo.xml". Additional files may also be written
-      containing information required by different analysers e.g. if there are managed code files
-      then a file called "ManagedFileList" will be written containing the list of managed code
-      files that was passed to the compiler.
-      
-      The output will only be produced if the properties $(SonarQubeOutputPath) and 
-      $(RunSonarQubeAnalysis) are specified. $(SonarQubeOutputPath) is the output directory 
-      in which the output file should be dropped and can be relative or absolute 
-      (use an absolute path if you want a consolidated set of output for a single build).
-
-      Using this targets file
-      - - - - - - - - - - - -
-      To use these targets with a single project, import the targets into that project.
-
-      To use these targets with all projects, put the file in:
-          C:\Program Files (x86)\MSBuild\12.0\Microsoft.Common.Targets\ImportBefore
-      ... adjusting the MSBuild version as necessary.
-
-
-      Example of use:
-      - - - - - - - -
-      msbuild MyProject.csproj /p:SonarQubeOutputPath=C:\SQOutput /p:RunSonarQubeAnalysis=true
-
-
-      Excluding projects and files from SonarQube analysis
-      ****************************************************
-      Individual projects can excluded from SonarQube analysis by setting
-      the property $(SonarQubeExclude) e.g.
-      
-        <SonarQubeExclude>true</SonarQubeExclude>
-
-      Individual files can be excluded from analysis by setting the 
-      <SonarQubeExclude> metadata item e.g.
-      
-        <Compile Include="Logger.cs">
-          <SonarQubeExclude>true</SonarQubeExclude>
-        </Compile>
+  <!-- **************************************************************************** -->
+  <!-- SonarQube MSBuild Integration implementation logic -->
+  <!-- **************************************************************************** -->
   
-  
-      Test projects
-      *************
-      The analysis performed by SonarQube varies depending on whether a project
-      is a test project or not.
-
-      A project can be explicitly marked as being a test or product project by setting
-      the property $(c) e.g.
-      
-        <SonarQubeTestProject>true</SonarQubeTestProject>
-       
-      If the $(SonarQubeTestProject) is not set then the targets will determine the project
-      type as follows:
-      
-      1) Projects whose full project file name matches the regular expression in the analysis
-         config file will be treated as test projects. This is set via the SonarQube portal
-         (the "Test project pattern" in the per-project settings for C#).
-          By default, any projects with:
-          * "test" (case-insensitive) in the project name, or
-          * that have a directory called "test" or "tests" in the path
-          will be treated as test projects
-          
-          Note that the regular expression uses the .Net Regex format i.e. "+" is the
-          single character wildcard and "*" is the multi-character wildcard (zero to many).
-          
-      2) MSTest projects will be treated as test projects.
-          The $(ProjectTypeGuid) of MS Test projects contains a specific guid
-          ("3AC096D0-A1C2-E12C-1390-A8335801FDAB")
-  
--->
-
   <!-- Safeguard against importing this .targets file multiple times -->
   <PropertyGroup>
     <SonarQubeTargetsImported>true</SonarQubeTargetsImported>
   </PropertyGroup>
 
   <!-- Set defaults if explicit values have not been provided -->
-  <PropertyGroup Condition="$(RunSonarQubeAnalysis) == 'true' ">
-    <!-- Use the TeamBuild per-build base directory as a root -->
-    <!-- Legacy TeamBuild system i.e. XAML Builds (pre-2015) -->
-    <SonarQubeTempPath Condition=" $(SonarQubeTempPath) == '' AND $(TF_BUILD_BUILDDIRECTORY) != '' "
-                   >$(TF_BUILD_BUILDDIRECTORY)\sqtemp</SonarQubeTempPath>
+  <PropertyGroup Condition=" $(SonarQubeTempPath) != '' ">
+    <SonarQubeConfigPath Condition=" $(SonarQubeConfigPath) == '' ">$(SonarQubeTempPath)\conf\</SonarQubeConfigPath>
+    <SonarQubeOutputPath Condition=" $(SonarQubeOutputPath) == '' ">$(SonarQubeTempPath)\out\</SonarQubeOutputPath>
 
-    <!-- New TeamBuild system (2015 onwards) -->
-    <SonarQubeTempPath Condition=" $(SonarQubeTempPath) == '' AND $(AGENT_BUILDDIRECTORY) != '' "
-                   >$(AGENT_BUILDDIRECTORY)\sqtemp</SonarQubeTempPath>
-
-    <SonarQubeConfigPath Condition="$(SonarQubeConfigPath) == '' AND $(SonarQubeTempPath) !='' "
-                     >$(SonarQubeTempPath)\conf\</SonarQubeConfigPath>
-
-    <SonarQubeOutputPath Condition="$(SonarQubeOutputPath) == '' AND $(SonarQubeTempPath) !='' "
-                     >$(SonarQubeTempPath)\out\</SonarQubeOutputPath>
-
-  
     <!-- Specify the ItemGroups to be analyzed -->
     <SQAnalysisFileItemTypes Condition=" $(SQAnalysisFileItemTypes) == '' ">Compile;Content;EmbeddedResource;None;ClCompile;Page;TypeScriptCompile</SQAnalysisFileItemTypes>
-
   </PropertyGroup>
-  
+
   <!-- **************************************************************************** -->
   <!-- Using tasks -->
   <!-- **************************************************************************** -->
-  <PropertyGroup Condition="$(RunSonarQubeAnalysis) == 'true' ">
+  <PropertyGroup Condition=" $(SonarQubeTempPath) != '' ">
     <!-- Assume that the tasks assembly is in the same location as this targets file 
          or in a parent directory unless another location has already been specified. -->
     <SonarQubeBuildTasksAssemblyFile Condition=" $(SonarQubeBuildTasksAssemblyFile) == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SonarQube.MSBuild.Tasks.dll))\SonarQube.MSBuild.Tasks.dll</SonarQubeBuildTasksAssemblyFile>
@@ -124,8 +38,8 @@
   <!-- **************************************************************************** -->
 
   <Target Name="SkippingSonarQubeAnalysis" BeforeTargets="CoreCompile"
-          Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeOutputPath) == '' ">
-    <Message Importance="high" Text="Skipping dumping compile outputs because SonarQubeOutputPath has not been specified" />
+          Condition=" $(SonarQubeTempPath) == '' ">
+    <Message Importance="high" Text="Skipping dumping compile outputs because SonarQubeTempPath has not been specified" />
   </Target>
 
   <!-- **************************************************************************** -->
@@ -140,12 +54,12 @@
     -->
   <Target Name="SonarQubeCategoriseProject"
           BeforeTargets="CoreCompile"
-          Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeOutputPath) != '' AND $(SonarQubeTestProject) == '' " >
+          Condition=" $(SonarQubeTempPath) != '' AND $(SonarQubeTestProject) == '' " >
 
     <PropertyGroup>
       <!-- The MS Test project type guid-->
-      <SonarMsTestProjectTypeGuid>3AC096D0-A1C2-E12C-1390-A8335801FDAB</SonarMsTestProjectTypeGuid>
-      <SonarQubeTestProject Condition=" $(ProjectTypeGuid.ToUpperInvariant().Contains('$(SonarMsTestProjectTypeGuid)')) ">true</SonarQubeTestProject>
+      <SonarQubeMsTestProjectTypeGuid>3AC096D0-A1C2-E12C-1390-A8335801FDAB</SonarQubeMsTestProjectTypeGuid>
+      <SonarQubeTestProject Condition=" $(ProjectTypeGuid.ToUpperInvariant().Contains('$(SonarQubeMsTestProjectTypeGuid)')) ">true</SonarQubeTestProject>
     </PropertyGroup>
 
     <!-- If we haven't already determined whether the project is a test project then check
@@ -162,7 +76,7 @@
   <!-- Calculate the set of files to be analyzed -->
   <!-- **************************************************************************** -->
   <Target Name="CalculateSonarQubeFilesToAnalyze" AfterTargets="CoreCompile" BeforeTargets="RunCodeAnalysis"
-        Condition="$(RunSonarQubeAnalysis) == 'true' ">
+        Condition=" $(SonarQubeTempPath) != '' ">
 
     <!-- Include all of contents of the specified item groups, but exclude 
          any that have the metadata 'SonarQubeExclude' set, or that are auto-generated -->
@@ -187,7 +101,7 @@
   -->
   <!-- **************************************************************************** -->
   <Target Name="WriteSonarQubeProjectData" AfterTargets="Build"
-        Condition="$(RunSonarQubeAnalysis) == 'true' AND  $(SonarQubeOutputPath) != '' ">
+        Condition=" $(SonarQubeTempPath) != '' ">
     
     <!-- **************************************************************************** -->
     <!-- Create the project-specific directory -->
@@ -265,18 +179,15 @@
   
   <!-- The FxCop targets are conditionally imported so we need to make sure the required condition
        is true early enough. -->
-  <PropertyGroup Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeOutputPath) != '' ">
+  <PropertyGroup Condition=" $(SonarQubeTempPath) != '' ">
     <SonarQubeRulesetFileName Condition=" $(SonarQubeRulesetFileName) == ''">SonarQubeAnalysis.ruleset</SonarQubeRulesetFileName>
     <SonarQubeRulesetFullName>$(SonarQubeConfigPath)\$(SonarQubeRulesetFileName)</SonarQubeRulesetFullName>
-
-    <!-- If the config path hasn't been specified then don't run code analysis-->
-    <SonarQubeRulesetExists Condition=" $(SonarQubeConfigPath) == '' ">false</SonarQubeRulesetExists>
-    <SonarQubeRulesetExists Condition=" $(SonarQubeConfigPath) != '' ">$([System.IO.File]::Exists($(SonarQubeRulesetFullName)))</SonarQubeRulesetExists>
+    <SonarQubeRulesetExists>$([System.IO.File]::Exists($(SonarQubeRulesetFullName)))</SonarQubeRulesetExists>
 
     <!-- If we are running a SonarQube analysis build then whether or not FxCop is run depends entirely on whether
          the SonarQube settings -->
     <SonarQubeRunMSCodeAnalysis>$(SonarQubeRulesetExists)</SonarQubeRunMSCodeAnalysis>
-    <SonarQubeRunMSCodeAnalysis Condition="$(SonarQubeExclude) == 'true' ">false</SonarQubeRunMSCodeAnalysis>
+    <SonarQubeRunMSCodeAnalysis Condition=" $(SonarQubeExclude) == 'true' ">false</SonarQubeRunMSCodeAnalysis>
     <!-- It's too early to be certain whether the project is a test project or not as the "categorise" target
          hasn't run yet. We'll exclude test projects from FxCop analysis in "OverrideCodeAnalysisProperties". -->
 
@@ -284,7 +195,7 @@
   </PropertyGroup>
 
   <!-- We want to override any properties that have been set declaratively in the project -->
-  <Target Name="OverrideCodeAnalysisProperties" Condition="$(RunSonarQubeAnalysis) == 'true' AND $(SonarQubeOutputPath) != '' "
+  <Target Name="OverrideCodeAnalysisProperties" Condition=" $(SonarQubeTempPath) != '' "
           BeforeTargets="RunCodeAnalysis" >
 
     <PropertyGroup>
@@ -328,18 +239,18 @@
           Condition=" $(SonarQubeRunMSCodeAnalysis) == 'true' "
           AfterTargets="RunCodeAnalysis" BeforeTargets="WriteSonarQubeProjectData" >
 
-    <!-- TODO: update to support native files -->
+    <!-- TODO: remove this duplicated logic -->
     <ItemGroup>
       <!-- Work out if there were any managed files to be analyzed.
            Exclude any that have the metadata 'SonarQubeExclude' set, or that are auto-generated -->
       <SonarQubeManagedFiles Include="@(Compile)" Condition=" %(Compile.SonarQubeExclude) != 'true' AND %(Compile.AutoGen) != 'true' " />
     </ItemGroup>
-    
+
     <PropertyGroup>
       <!-- Work out which types of input files exist-->
       <ManagedFilesExist Condition=" @(SonarQubeManagedFiles) != '' ">true</ManagedFilesExist>
     </PropertyGroup>
-    
+
     <ItemGroup Condition=" $(ManagedFilesExist) == 'true' ">
       <AnalysisResults Include="$(CodeAnalysisLogFile)">
         <Id>FxCop</Id>

--- a/SonarQube.TeamBuild.Integration/TeamBuildSettings.cs
+++ b/SonarQube.TeamBuild.Integration/TeamBuildSettings.cs
@@ -205,7 +205,7 @@ namespace SonarQube.TeamBuild.Integration
         {
             get
             {
-                return Path.Combine(this.BuildDirectory, "sqtemp", "conf");
+                return Path.Combine(this.BuildDirectory, ".sonarqube", "conf");
             }
         }
 
@@ -213,7 +213,7 @@ namespace SonarQube.TeamBuild.Integration
         {
             get
             {
-                return Path.Combine(this.BuildDirectory, "sqtemp", "out");
+                return Path.Combine(this.BuildDirectory, ".sonarqube", "out");
             }
         }
 

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
@@ -38,7 +38,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // 2. Now clear the config scope and check the env var is used
                 configScope.Reset();
                 settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(@"env download dir\sqtemp\bin", settings);
+                AssertExpectedDownloadDir(@"env download dir\.sonarqube\bin", settings);
             }
         }
 
@@ -56,7 +56,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
                 
                 IBootstrapperSettings settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(@"legacy tf build\sqtemp\bin", settings);
+                AssertExpectedDownloadDir(@"legacy tf build\.sonarqube\bin", settings);
             }
 
             // 2. TFS2015 variable will be used if available
@@ -67,7 +67,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, "tfs build");
                 
                 IBootstrapperSettings settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(@"tfs build\sqtemp\bin", settings);
+                AssertExpectedDownloadDir(@"tfs build\.sonarqube\bin", settings);
             }
 
             // 3. SQ variable takes precedence over the other variables
@@ -78,7 +78,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, "tfs build");
 
                 IBootstrapperSettings settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(@"sq build\sqtemp\bin", settings);
+                AssertExpectedDownloadDir(@"sq build\.sonarqube\bin", settings);
             }
         }
 
@@ -123,12 +123,12 @@ namespace SonarQube.Bootstrapper.Tests
 
                 // 1. Default value -> relative to download dir
                 IBootstrapperSettings settings = new BootstrapperSettings(logger, configScope.AppConfig);
-                AssertExpectedPostProcessPath(@"c:\temp\sqtemp\bin\SonarQube.MSBuild.PostProcessor.exe", settings);
+                AssertExpectedPostProcessPath(@"c:\temp\.sonarqube\bin\SonarQube.MSBuild.PostProcessor.exe", settings);
 
                 // 2. Relative exe set in config -> relative to download dir
                 configScope.SetPostProcessExe(@"..\foo\myCustomPreProcessor.exe");
                 settings = new BootstrapperSettings(logger, configScope.AppConfig);
-                AssertExpectedPostProcessPath(@"c:\temp\sqtemp\foo\myCustomPreProcessor.exe", settings);
+                AssertExpectedPostProcessPath(@"c:\temp\.sonarqube\foo\myCustomPreProcessor.exe", settings);
 
                 // 3. Now set the config path to an absolute value
                 configScope.SetPostProcessExe(@"d:\myCustomPostProcessor.exe");

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
@@ -306,7 +306,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
         {
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
-            
+
+            preImportProperties.SonarQubeTempPath = outputPath; // FIXME
             preImportProperties.SonarQubeConfigPath = configPath;
             preImportProperties.SonarQubeOutputPath = outputPath;
             

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
@@ -94,6 +94,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.SonarQubeConfigPath = rootInputFolder;
             preImportProperties.RunCodeAnalysis = "TRUE";
@@ -131,6 +132,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.RunCodeAnalysis = "true"; // our targets should override this value
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
@@ -170,6 +172,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.RunCodeAnalysis = "false";
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
@@ -220,6 +223,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.RunCodeAnalysis = "false";
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
@@ -276,6 +280,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
             preImportProperties.CodeAnalysisRuleset = "specifiedInProject.ruleset";
@@ -326,6 +331,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
             preImportProperties.CodeAnalysisRuleset = "specifiedInProject.ruleset";
@@ -380,6 +386,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
             preImportProperties.CodeAnalysisRuleset = "specifiedInProject.ruleset";
@@ -435,6 +442,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             string fxCopLogFile = Path.Combine(rootInputFolder, "FxCopResults.xml");
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "true";
+            preImportProperties.SonarQubeTempPath = rootOutputFolder; // FIXME
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
             preImportProperties.CodeAnalysisRuleset = "specifiedInProject.ruleset";

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/SonarIntegrationTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/SonarIntegrationTargetsTests.cs
@@ -8,6 +8,7 @@
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using TestUtilities;
 
 namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
@@ -82,6 +83,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "TRUE";
+            preImportProperties.SonarQubeTempPath = @"t:\TeamBuildDir_Legacy\.sonarqube";
             preImportProperties.TeamBuildLegacyBuildDirectory = @"t:\TeamBuildDir_Legacy";
             preImportProperties.TeamBuild2105BuildDirectory = "";
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
@@ -90,8 +92,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             ProjectInstance projectInstance = new ProjectInstance(projectRoot.FullPath);
 
             // Assert
-            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeOutputPath, @"t:\TeamBuildDir_Legacy\sqtemp\out\");
-            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeConfigPath, @"t:\TeamBuildDir_Legacy\sqtemp\conf\");
+            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeOutputPath, @"t:\TeamBuildDir_Legacy\.sonarqube\out\");
+            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeConfigPath, @"t:\TeamBuildDir_Legacy\.sonarqube\conf\");
         }
 
         [TestMethod]
@@ -103,6 +105,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
             WellKnownProjectProperties preImportProperties = new WellKnownProjectProperties();
             preImportProperties.RunSonarQubeAnalysis = "TRUE";
+            preImportProperties.SonarQubeTempPath = @"t:\TeamBuildDir_NonLegacy\.sonarqube"; // FIXME
             preImportProperties.TeamBuildLegacyBuildDirectory = "";
             preImportProperties.TeamBuild2105BuildDirectory = @"t:\TeamBuildDir_NonLegacy";
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
@@ -111,8 +114,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             ProjectInstance projectInstance = new ProjectInstance(projectRoot.FullPath);
 
             // Assert
-            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeOutputPath, @"t:\TeamBuildDir_NonLegacy\sqtemp\out\");
-            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeConfigPath, @"t:\TeamBuildDir_NonLegacy\sqtemp\conf\");
+            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeOutputPath, @"t:\TeamBuildDir_NonLegacy\.sonarqube\out\");
+            BuildAssertions.AssertExpectedPropertyValue(projectInstance, TargetProperties.SonarQubeConfigPath, @"t:\TeamBuildDir_NonLegacy\.sonarqube\conf\");
         }
 
         [TestMethod]

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
@@ -461,6 +461,13 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             preImportProperties.RunSonarQubeAnalysis = "true";
             preImportProperties.SonarQubeOutputPath = rootOutputFolder;
 
+            // The temp folder needs to be set for the targets to succeed. Use the temp folder
+            // if one has not been supplied.
+            if (string.IsNullOrEmpty(preImportProperties.SonarQubeTempPath))
+            {
+                preImportProperties.SonarQubeTempPath = Path.GetTempPath();
+            }
+
             // The config folder needs to be set for the targets to succeed. Use the temp folder
             // if one has not been supplied.
             if (string.IsNullOrEmpty(preImportProperties.SonarQubeConfigPath))

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/TeamBuildSettingsTests.cs
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/TeamBuildSettingsTests.cs
@@ -237,9 +237,9 @@ namespace SonarQube.TeamBuild.Integration.Tests
             Assert.AreEqual(expectedCollectionUri, actual.TfsUri, "Unexpected tfs uri returned");
 
             // Check the calculated values
-            Assert.AreEqual(Path.Combine(expectedDir, "sqtemp\\conf"), actual.SonarConfigDirectory, "Unexpected config dir");
-            Assert.AreEqual(Path.Combine(expectedDir, "sqtemp\\out"), actual.SonarOutputDirectory, "Unexpected output dir");
-            Assert.AreEqual(Path.Combine(expectedDir, "sqtemp\\conf", FileConstants.ConfigFileName), actual.AnalysisConfigFilePath, "Unexpected analysis file path");
+            Assert.AreEqual(Path.Combine(expectedDir, ".sonarqube\\conf"), actual.SonarConfigDirectory, "Unexpected config dir");
+            Assert.AreEqual(Path.Combine(expectedDir, ".sonarqube\\out"), actual.SonarOutputDirectory, "Unexpected output dir");
+            Assert.AreEqual(Path.Combine(expectedDir, ".sonarqube\\conf", FileConstants.ConfigFileName), actual.AnalysisConfigFilePath, "Unexpected analysis file path");
         }
 
         private static void CheckExpectedTimeoutReturned(string envValue, int expected)

--- a/VsoBuildStepSources/SonarQubePostBuild/SonarQubePostBuild.ps1
+++ b/VsoBuildStepSources/SonarQubePostBuild/SonarQubePostBuild.ps1
@@ -19,7 +19,7 @@ if (!$agentBuildDirectory)
 }
 
 # Upload the summary markdown file
-$summaryMdPath = [System.IO.Path]::Combine($agentBuildDirectory, "sqtemp", "out", "summary.md")
+$summaryMdPath = [System.IO.Path]::Combine($agentBuildDirectory, ".sonarqube", "out", "summary.md")
 Write-Verbose -Verbose "summaryMdPath = $summaryMdPath"
 
 if ([System.IO.File]::Exists($summaryMdPath))


### PR DESCRIPTION
This quite large PR includes the following:

1) Support of the current working directory as a temporary analysis folder - it does not clean the folder automatically during the preprocessing step (that will come with http://jira.sonarsource.com/browse/SONARMSBRU-50)
2) Logic simplification within targets files: The presence of `SonarQubeTempPath` is now driving whether or not to perform the analysis, whereas it previously was a combination of that plus `RunSonarQubeAnalysis`. The implementation targets file also no longer knows anything about TFS 2013 or 2015
3) A few hacks are introduced to keep the integration tests running. I'll submit a separate PR to factorize the logic to run an end-to-end test, so that we won't have to update many places in case of future changes in the targets files.