### PR TITLE
SONARMSBRU-43 Use the .sonarqube folder in CWD in the bootstrapper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 *.targets eol=crlf
 *.resx eol=crlf
 *.csproj eol=crlf
+*.settings eol=crlf

--- a/SonarQube.Bootstrapper/App.config
+++ b/SonarQube.Bootstrapper/App.config
@@ -16,9 +16,6 @@
             <setting name="PostProcessExe" serializeAs="String">
                 <value>SonarQube.MSBuild.PostProcessor.exe</value>
             </setting>
-            <setting name="DownloadDir" serializeAs="String">
-                <value />
-            </setting>
             <setting name="PreProcessorTimeoutInMs" serializeAs="String">
                 <value>300000</value>
             </setting>

--- a/SonarQube.Bootstrapper/BootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/BootstrapperSettings.cs
@@ -28,8 +28,8 @@ namespace SonarQube.Bootstrapper
                 BuildDirectory_TFS2015      // TeamBuild 2015 and later build directory
                };
 
-        private const string RelativePathToTempDir = @".sonarqube";
-        private const string RelativePathToDownloadDir = @"bin";
+        public const string RelativePathToTempDir = @".sonarqube";
+        public const string RelativePathToDownloadDir = @"bin";
 
 
         private Settings appConfig;
@@ -166,11 +166,6 @@ namespace SonarQube.Bootstrapper
             }
 
             return Path.Combine(rootDir, RelativePathToTempDir);
-        }
-
-        private static string CalculateDownloadDir(Settings settings, ILogger logger)
-        {
-            return Path.Combine(CalculateTempDir(settings, logger), RelativePathToDownloadDir);
         }
 
         /// <summary>

--- a/SonarQube.Bootstrapper/IBootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/IBootstrapperSettings.cs
@@ -15,12 +15,12 @@ namespace SonarQube.Bootstrapper
         string SonarQubeUrl { get; }
 
         /// <summary>
-        /// Temporary analysis directory
+        /// Temporary analysis directory, usually .sonarqube
         /// </summary>
         string TempDirectory { get; }
 
         /// <summary>
-        /// Directory into which the downloaded files should be placed
+        /// Directory into which the downloaded files should be placed, usually .sonarqube\bin
         /// </summary>
         string DownloadDirectory { get; }
 

--- a/SonarQube.Bootstrapper/IBootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/IBootstrapperSettings.cs
@@ -15,6 +15,11 @@ namespace SonarQube.Bootstrapper
         string SonarQubeUrl { get; }
 
         /// <summary>
+        /// Temporary analysis directory
+        /// </summary>
+        string TempDirectory { get; }
+
+        /// <summary>
         /// Directory into which the downloaded files should be placed
         /// </summary>
         string DownloadDirectory { get; }

--- a/SonarQube.Bootstrapper/Program.cs
+++ b/SonarQube.Bootstrapper/Program.cs
@@ -60,7 +60,7 @@ namespace SonarQube.Bootstrapper
 
             var preprocessorFilePath = settings.PreProcessorFilePath;
             var processRunner = new ProcessRunner();
-            processRunner.Execute(preprocessorFilePath, string.Join(" ", args.Select(a => "\"" + a + "\"")), downloadBinPath, settings.PreProcessorTimeoutInMs, logger);
+            processRunner.Execute(preprocessorFilePath, string.Join(" ", args.Select(a => "\"" + a + "\"")), settings.TempDirectory, settings.PreProcessorTimeoutInMs, logger);
             
             return processRunner.ExitCode;
         }
@@ -70,7 +70,7 @@ namespace SonarQube.Bootstrapper
             var postprocessorFilePath = settings.PostProcessorFilePath;
 
             var processRunner = new ProcessRunner();
-            processRunner.Execute(postprocessorFilePath, "", settings.DownloadDirectory, settings.PostProcessorTimeoutInMs, logger);
+            processRunner.Execute(postprocessorFilePath, "", settings.TempDirectory, settings.PostProcessorTimeoutInMs, logger);
             return processRunner.ExitCode;
         }
 

--- a/SonarQube.Bootstrapper/Properties/Settings.Designer.cs
+++ b/SonarQube.Bootstrapper/Properties/Settings.Designer.cs
@@ -43,15 +43,6 @@ namespace SonarQube.Bootstrapper.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string DownloadDir {
-            get {
-                return ((string)(this["DownloadDir"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("300000")]
         public int PreProcessorTimeoutInMs {
             get {

--- a/SonarQube.Bootstrapper/Properties/Settings.settings
+++ b/SonarQube.Bootstrapper/Properties/Settings.settings
@@ -8,9 +8,6 @@
     <Setting Name="PostProcessExe" Type="System.String" Scope="Application">
       <Value Profile="(Default)">SonarQube.MSBuild.PostProcessor.exe</Value>
     </Setting>
-    <Setting Name="DownloadDir" Type="System.String" Scope="Application">
-      <Value Profile="(Default)" />
-    </Setting>
     <Setting Name="PreProcessorTimeoutInMs" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">300000</Value>
     </Setting>

--- a/SonarQube.TeamBuild.Integration/TeamBuildSettings.cs
+++ b/SonarQube.TeamBuild.Integration/TeamBuildSettings.cs
@@ -23,12 +23,6 @@ namespace SonarQube.TeamBuild.Integration
         public static class EnvironmentVariables // was internal
         {
             /// <summary>
-            /// Name of the environment variable that specifies the directory to use as the 
-            /// analysis root in non-TFS cases
-            /// </summary>
-            public const string SQAnalysisRootPath = "SQ_BUILDDIRECTORY";
-
-            /// <summary>
             /// Name of the environment variable that specifies whether the processing
             /// of code coverage reports in legacy TeamBuild cases should be skipped
             /// </summary>
@@ -45,12 +39,10 @@ namespace SonarQube.TeamBuild.Integration
             // Legacy TeamBuild environment variables (XAML Builds)
             public const string TfsCollectionUri_Legacy = "TF_BUILD_COLLECTIONURI";
             public const string BuildUri_Legacy = "TF_BUILD_BUILDURI";
-            public const string BuildDirectory_Legacy = "TF_BUILD_BUILDDIRECTORY";
 
             // TFS 2015 Environment variables
             public const string TfsCollectionUri_TFS2015 = "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI";
             public const string BuildUri_TFS2015 = "BUILD_BUILDURI";
-            public const string BuildDirectory_TFS2015 = "AGENT_BUILDDIRECTORY";
         }
 
         #region Public static methods
@@ -80,7 +72,7 @@ namespace SonarQube.TeamBuild.Integration
                         BuildEnvironment = env,
                         BuildUri = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUri_Legacy),
                         TfsUri = Environment.GetEnvironmentVariable(EnvironmentVariables.TfsCollectionUri_Legacy),
-                        BuildDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildDirectory_Legacy)
+                        BuildDirectory = Directory.GetCurrentDirectory()
                     };
 
                     break;
@@ -92,7 +84,7 @@ namespace SonarQube.TeamBuild.Integration
                         BuildEnvironment = env,
                         BuildUri = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUri_TFS2015),
                         TfsUri = Environment.GetEnvironmentVariable(EnvironmentVariables.TfsCollectionUri_TFS2015),
-                        BuildDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildDirectory_TFS2015)
+                        BuildDirectory = Directory.GetCurrentDirectory()
                     };
                     
                     break;
@@ -100,16 +92,10 @@ namespace SonarQube.TeamBuild.Integration
                 default:
                     logger.LogMessage(Resources.SETTINGS_NotInTeamBuild);
 
-                    string buildDir = Environment.GetEnvironmentVariable(EnvironmentVariables.SQAnalysisRootPath);
-                    if (string.IsNullOrEmpty(buildDir))
-                    {
-                        buildDir = Path.GetTempPath();
-                    }
-
                     settings = new TeamBuildSettings()
                     {
                         BuildEnvironment = env,
-                        BuildDirectory = buildDir
+                        BuildDirectory = Directory.GetCurrentDirectory()
                     };
 
                     break;
@@ -205,7 +191,7 @@ namespace SonarQube.TeamBuild.Integration
         {
             get
             {
-                return Path.Combine(this.BuildDirectory, ".sonarqube", "conf");
+                return Path.Combine(this.BuildDirectory, "conf");
             }
         }
 
@@ -213,7 +199,7 @@ namespace SonarQube.TeamBuild.Integration
         {
             get
             {
-                return Path.Combine(this.BuildDirectory, ".sonarqube", "out");
+                return Path.Combine(this.BuildDirectory, "out");
             }
         }
 

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
@@ -15,6 +15,8 @@ namespace SonarQube.Bootstrapper.Tests
     {
         public TestContext TestContext { get; set; }
 
+        private static readonly string DownloadFolderRelativePath = Path.Combine(BootstrapperSettings.RelativePathToTempDir, BootstrapperSettings.RelativePathToDownloadDir);
+
         #region Tests
 
         [TestMethod]
@@ -30,7 +32,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
                 
                 IBootstrapperSettings settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(@"legacy tf build\.sonarqube\bin", settings);
+                AssertExpectedDownloadDir(Path.Combine("legacy tf build", DownloadFolderRelativePath), settings);
             }
 
             // 2. TFS2015 variable will be used if available
@@ -40,7 +42,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, "tfs build");
                 
                 IBootstrapperSettings settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(@"tfs build\.sonarqube\bin", settings);
+                AssertExpectedDownloadDir(Path.Combine("tfs build", DownloadFolderRelativePath), settings);
             }
 
             // 3. CWD has least precedence over env variables
@@ -50,7 +52,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
 
                 IBootstrapperSettings settings = new BootstrapperSettings(logger);
-                AssertExpectedDownloadDir(Path.Combine(Directory.GetCurrentDirectory(), @".sonarqube\bin"), settings);
+                AssertExpectedDownloadDir(Path.Combine(Directory.GetCurrentDirectory(), DownloadFolderRelativePath), settings);
             }
         }
 
@@ -69,12 +71,12 @@ namespace SonarQube.Bootstrapper.Tests
 
                 // 1. Default value -> relative to download dir
                 IBootstrapperSettings settings = new BootstrapperSettings(logger, configScope.AppConfig);
-                AssertExpectedPreProcessPath(@"c:\temp\.sonarqube\bin\SonarQube.MSBuild.PreProcessor.exe", settings);
+                AssertExpectedPreProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, "SonarQube.MSBuild.PreProcessor.exe"), settings);
 
                 // 2. Relative exe set in config -> relative to download dir
                 configScope.SetPreProcessExe(@"..\myCustomPreProcessor.exe");
                 settings = new BootstrapperSettings(logger, configScope.AppConfig);
-                AssertExpectedPreProcessPath(@"c:\temp\.sonarqube\myCustomPreProcessor.exe", settings);
+                AssertExpectedPreProcessPath(Path.Combine(@"c:\temp", BootstrapperSettings.RelativePathToTempDir, "myCustomPreProcessor.exe"), settings);
 
                 // 3. Now set the config path to an absolute value
                 configScope.SetPreProcessExe(@"d:\myCustomPreProcessor.exe");
@@ -100,12 +102,12 @@ namespace SonarQube.Bootstrapper.Tests
 
                 // 1. Default value -> relative to download dir
                 IBootstrapperSettings settings = new BootstrapperSettings(logger, configScope.AppConfig);
-                AssertExpectedPostProcessPath(@"c:\temp\.sonarqube\bin\SonarQube.MSBuild.PostProcessor.exe", settings);
+                AssertExpectedPostProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, "SonarQube.MSBuild.PostProcessor.exe"), settings);
 
                 // 2. Relative exe set in config -> relative to download dir
                 configScope.SetPostProcessExe(@"..\foo\myCustomPreProcessor.exe");
                 settings = new BootstrapperSettings(logger, configScope.AppConfig);
-                AssertExpectedPostProcessPath(@"c:\temp\.sonarqube\foo\myCustomPreProcessor.exe", settings);
+                AssertExpectedPostProcessPath(Path.Combine(@"c:\temp", BootstrapperSettings.RelativePathToTempDir, @"foo\myCustomPreProcessor.exe"), settings);
 
                 // 3. Now set the config path to an absolute value
                 configScope.SetPostProcessExe(@"d:\myCustomPostProcessor.exe");

--- a/Tests/SonarQube.Bootstrapper.Tests/Infrastructure/AppConfigWrapper.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/Infrastructure/AppConfigWrapper.cs
@@ -33,13 +33,6 @@ namespace SonarQube.Bootstrapper.Tests
             this.appConfig.Reset();
         }
 
-        public void SetDownloadDir(string value)
-        {
-            // Dummy access to ensure the properties are initialised
-            string dummy = this.appConfig.DownloadDir;
-            this.appConfig.PropertyValues["DownloadDir"].PropertyValue = value;
-        }
-
         public void SetPreProcessExe(string value)
         {
             // Dummy access to ensure the properties are initialised

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/TeamBuildSettingsTests.cs
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/TeamBuildSettingsTests.cs
@@ -123,40 +123,21 @@ namespace SonarQube.TeamBuild.Integration.Tests
             TestLogger logger;
             TeamBuildSettings settings;
 
-            // 1. No environment vars set -> use the temp path
+            // 1. No environment vars set
             using (EnvironmentVariableScope scope = new EnvironmentVariableScope())
             {
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.SQAnalysisRootPath, null);
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.IsInTeamBuild, null);
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_Legacy, null);
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_TFS2015, null);
 
                 logger = new TestLogger();
                 settings = TeamBuildSettings.GetSettingsFromEnvironment(logger);
 
                 // Check the environment properties
-                CheckExpectedSettings(settings, BuildEnvironment.NotTeamBuild, Path.GetTempPath(), null, null);
+                CheckExpectedSettings(settings, BuildEnvironment.NotTeamBuild, Directory.GetCurrentDirectory(), null, null);
             }
 
-            // 2. SQ analysis dir set
-            using(EnvironmentVariableScope scope = new EnvironmentVariableScope())
-            {
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.SQAnalysisRootPath, "d:\\sqdir");
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.IsInTeamBuild, null);
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_Legacy, null);
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_TFS2015, null);
-
-                logger = new TestLogger();
-                settings = TeamBuildSettings.GetSettingsFromEnvironment(logger);
-
-                CheckExpectedSettings(settings, BuildEnvironment.NotTeamBuild, "d:\\sqdir", null, null);
-            }
-
-
-            // 3. Some Team build settings provided, but not marked as in team build
+            // 2. Some Team build settings provided, but not marked as in team build
             using (EnvironmentVariableScope scope = new EnvironmentVariableScope())
             {
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.SQAnalysisRootPath, "x:\\a");
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.IsInTeamBuild, null);
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildUri_Legacy, "build uri");
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.TfsCollectionUri_Legacy, "collection uri");
@@ -164,7 +145,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
                 logger = new TestLogger();
                 settings = TeamBuildSettings.GetSettingsFromEnvironment(logger);
 
-                CheckExpectedSettings(settings, BuildEnvironment.NotTeamBuild, "x:\\a", null, null);
+                CheckExpectedSettings(settings, BuildEnvironment.NotTeamBuild, Directory.GetCurrentDirectory(), null, null);
             }
 
         }
@@ -179,7 +160,6 @@ namespace SonarQube.TeamBuild.Integration.Tests
             using (EnvironmentVariableScope scope = new EnvironmentVariableScope())
             {
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.IsInTeamBuild, "TRUE");
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_Legacy, "build dir");
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildUri_Legacy, "http://legacybuilduri");
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.TfsCollectionUri_Legacy, "http://legacycollectionUri");
 
@@ -193,7 +173,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             logger.AssertWarningsLogged(0);
 
             // Check the environment properties
-            CheckExpectedSettings(settings, BuildEnvironment.LegacyTeamBuild, "build dir", "http://legacybuilduri", "http://legacycollectionUri");
+            CheckExpectedSettings(settings, BuildEnvironment.LegacyTeamBuild, Directory.GetCurrentDirectory(), "http://legacybuilduri", "http://legacycollectionUri");
         }
 
         [TestMethod]
@@ -206,7 +186,6 @@ namespace SonarQube.TeamBuild.Integration.Tests
             using (EnvironmentVariableScope scope = new EnvironmentVariableScope())
             {
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.IsInTeamBuild, "TRUE");
-                scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_TFS2015, "build dir");
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildUri_TFS2015, "http://builduri");
                 scope.SetVariable(TeamBuildSettings.EnvironmentVariables.TfsCollectionUri_TFS2015, "http://collectionUri");
 
@@ -220,7 +199,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             logger.AssertWarningsLogged(0);
 
             // Check the environment properties
-            CheckExpectedSettings(settings, BuildEnvironment.TeamBuild, "build dir", "http://builduri", "http://collectionUri");
+            CheckExpectedSettings(settings, BuildEnvironment.TeamBuild, Directory.GetCurrentDirectory(), "http://builduri", "http://collectionUri");
         }
 
         #endregion
@@ -237,9 +216,9 @@ namespace SonarQube.TeamBuild.Integration.Tests
             Assert.AreEqual(expectedCollectionUri, actual.TfsUri, "Unexpected tfs uri returned");
 
             // Check the calculated values
-            Assert.AreEqual(Path.Combine(expectedDir, ".sonarqube\\conf"), actual.SonarConfigDirectory, "Unexpected config dir");
-            Assert.AreEqual(Path.Combine(expectedDir, ".sonarqube\\out"), actual.SonarOutputDirectory, "Unexpected output dir");
-            Assert.AreEqual(Path.Combine(expectedDir, ".sonarqube\\conf", FileConstants.ConfigFileName), actual.AnalysisConfigFilePath, "Unexpected analysis file path");
+            Assert.AreEqual(Path.Combine(expectedDir, "conf"), actual.SonarConfigDirectory, "Unexpected config dir");
+            Assert.AreEqual(Path.Combine(expectedDir, "out"), actual.SonarOutputDirectory, "Unexpected output dir");
+            Assert.AreEqual(Path.Combine(expectedDir, "conf", FileConstants.ConfigFileName), actual.AnalysisConfigFilePath, "Unexpected analysis file path");
         }
 
         private static void CheckExpectedTimeoutReturned(string envValue, int expected)

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/Infrastructure/PreprocessTestUtils.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/Infrastructure/PreprocessTestUtils.cs
@@ -16,17 +16,13 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
         /// Creates and returns an environment scope that contains all of the required
         /// legacy TeamBuild environment variables
         /// </summary>
-        public static EnvironmentVariableScope CreateValidLegacyTeamBuildScope(string tfsUri, string buildUri, string buildDir)
+        public static EnvironmentVariableScope CreateValidLegacyTeamBuildScope(string tfsUri, string buildUri)
         {
             EnvironmentVariableScope scope = new EnvironmentVariableScope();
             scope.SetVariable(TeamBuildSettings.EnvironmentVariables.IsInTeamBuild, "true");
             scope.SetVariable(TeamBuildSettings.EnvironmentVariables.TfsCollectionUri_Legacy, tfsUri);
             scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildUri_Legacy, buildUri);
-            scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_Legacy, buildDir);
 
-            // Make sure the other variables are not set
-            scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildDirectory_TFS2015, null);
-            scope.SetVariable(TeamBuildSettings.EnvironmentVariables.SQAnalysisRootPath, null);
             return scope;
         }
 

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorExeTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorExeTests.cs
@@ -26,8 +26,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
         public void PreProc_MissingCommandLineArgs()
         {
             // Arrange
-            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
-            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri", testDir))
+            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri"))
             {
                 // Act and assert
                 CheckExecutionFails();
@@ -39,25 +38,22 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
         [TestMethod]
         public void PreProc_MissingEnvVars()
         {
-            // Arrange
-            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
-            
             // 1. Missing tfs uri
-            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope(null, "build uri", testDir))
+            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope(null, "build uri"))
             {
                 // Act and assert
                 CheckExecutionFails("key", "name", "version", "properties");
             }
 
             // 2. Missing build uri
-            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", null, testDir))
+            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", null))
             {
                 // Act and assert
                 CheckExecutionFails("key", "name", "version", "properties");
             }
 
             // 3. Missing build directory
-            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri", null))
+            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri"))
             {
                 // Act and assert
                 CheckExecutionFails("key", "name", "version", "properties");

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
@@ -37,7 +37,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
 
             string expectedConfigFileName;
 
-            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "http://builduri", testDir))
+            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "http://builduri"))
             {
                 TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(new ConsoleLogger());
                 Assert.IsNotNull(settings, "Test setup error: TFS environment variables have not been set correctly");
@@ -83,7 +83,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
 
             string expectedConfigFileName;
 
-            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri", testDir))
+            using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri"))
             {
                 TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(new ConsoleLogger());
                 Assert.IsNotNull(settings, "Test setup error: TFS environment variables have not been set correctly");


### PR DESCRIPTION
The previous PR regarding SONARMSBRU-43 actually only changed the .targets files and the Build vNext powershell script to look for a `.sonarqube` folder in the current working directory, if executed outside of TFS.

This one applies the same strategy, but to the Bootstrapper and the TFS Integration.

Note that, the TFS Integration now no longer duplicated the logic to find the location of the `.sonarqube` folder: It expects it its own current working directory.

The bootstrapper, which knows how to compute the `.sonarqube` path, launches both the pre&post processors with their current working directory set to it appropriately.