### PR TITLE
SONARMSBRU-71: added unit tests for VB to check the analysis file lis…

### DIFF
--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
@@ -247,6 +247,32 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
         }
 
         [TestMethod]
+        [TestCategory("E2E"), TestCategory("Targets"), TestCategory("VB")]
+        public void E2E_HasManagedAndContentFiles_VB()
+        {
+            // Arrange
+            string rootInputFolder = TestUtils.CreateTestSpecificFolder(this.TestContext, "Inputs");
+            string rootOutputFolder = TestUtils.CreateTestSpecificFolder(this.TestContext, "Outputs");
+
+            ProjectDescriptor descriptor = BuildUtilities.CreateValidProjectDescriptor(rootInputFolder);
+
+            AddEmptyCodeFile(descriptor, rootInputFolder, ".vb");
+            AddEmptyCodeFile(descriptor, rootInputFolder, ".vb");
+
+            AddEmptyContentFile(descriptor, rootInputFolder);
+            AddEmptyContentFile(descriptor, rootInputFolder);
+
+            WellKnownProjectProperties preImportProperties = CreateDefaultAnalysisProperties(rootInputFolder, rootOutputFolder);
+
+            // Act
+            string projectDir = CreateAndBuildSonarProject(descriptor, rootOutputFolder, preImportProperties, isVBProject:true);
+
+            AssertFileExists(projectDir, ExpectedAnalysisFilesListFileName);
+
+            CheckProjectOutputFolder(descriptor, projectDir);
+        }
+
+        [TestMethod]
         [TestCategory("E2E"), TestCategory("Targets")]
         public void E2E_ExcludedProjects()
         {
@@ -272,9 +298,10 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
 
         #region Private methods
 
-        private void AddEmptyCodeFile(ProjectDescriptor descriptor, string projectFolder)
+        private void AddEmptyCodeFile(ProjectDescriptor descriptor, string projectFolder, string extension = "cs")
         {
-            string emptyCodeFilePath = Path.Combine(projectFolder, "empty_" + Guid.NewGuid().ToString() + ".cs");
+            string emptyCodeFilePath = Path.Combine(projectFolder, "empty_" + Guid.NewGuid().ToString() + ".xxx");
+            emptyCodeFilePath = Path.ChangeExtension(emptyCodeFilePath, extension);
             File.WriteAllText(emptyCodeFilePath, string.Empty);
             
             if (descriptor.ManagedSourceFiles == null)
@@ -322,9 +349,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
         /// The method will check the build succeeded and that a single project output file was created.
         /// </summary>
         /// <returns>The full path of the project-specsific directory that was created during the build</returns>
-        private string CreateAndBuildSonarProject(ProjectDescriptor descriptor, string rootOutputFolder, WellKnownProjectProperties preImportProperties)
+        private string CreateAndBuildSonarProject(ProjectDescriptor descriptor, string rootOutputFolder, WellKnownProjectProperties preImportProperties, bool isVBProject = false)
         {
-            ProjectRootElement projectRoot = BuildUtilities.CreateInitializedProjectRoot(this.TestContext, descriptor, preImportProperties);
+            ProjectRootElement projectRoot = BuildUtilities.CreateInitializedProjectRoot(this.TestContext, descriptor, preImportProperties, isVBProject);
 
             BuildLogger logger = new BuildLogger();
 

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/ImportBeforeTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/ImportBeforeTargetsTests.cs
@@ -259,7 +259,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             string testSpecificFolder = TestUtils.EnsureTestSpecificFolder(this.TestContext);
             string fullProjectPath = Path.Combine(testSpecificFolder, projectName);
 
-            ProjectRootElement root = BuildUtilities.CreateMinimalBuildableProject(preImportProperties, importsBeforeTargets);
+            ProjectRootElement root = BuildUtilities.CreateMinimalBuildableProject(preImportProperties, false /* not a VB project */, importsBeforeTargets);
             root.AddProperty(TargetProperties.ProjectGuid, Guid.NewGuid().ToString("D"));
 
             root.Save(fullProjectPath);


### PR DESCRIPTION
…t and FxCop results

The new tests cover the creation of the analysis file list and FxCop report from by the targets. They don't cover the end-to-end (i.e. getting the Quality Rules from the SonarQube server and generating the sonar-runner.properties file).