### PR TITLE
SONRMSBRU-79: added global property file class...

### DIFF
--- a/SonarQube.Common/AnalysisConfig/AnalysisSetting.cs
+++ b/SonarQube.Common/AnalysisConfig/AnalysisSetting.cs
@@ -15,7 +15,7 @@ namespace SonarQube.Common
     /// <summary>
     /// Data class to describe an additional analysis configuration setting
     /// /// </summary>
-    /// <remarks>The class is XML-serializable.
+    /// <remarks>The class is XML-serializable</remarks>
     public class AnalysisSetting
     {
         #region Data

--- a/SonarQube.Common/AnalysisProperties/AggregatePropertiesProvider.cs
+++ b/SonarQube.Common/AnalysisProperties/AggregatePropertiesProvider.cs
@@ -1,0 +1,78 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AggregatePropertiesProvider.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Properties provider that aggregates the properties from multiple "child" providers.
+    /// The child providers are checked in order until one of them returns a value.
+    /// </summary>
+    public class AggregatePropertiesProvider : IAnalysisPropertyProvider
+    {
+        /// <summary>
+        /// Ordered list of child providers
+        /// </summary>
+        private readonly IAnalysisPropertyProvider[] providers;
+
+        #region Public methods
+
+        public AggregatePropertiesProvider(params IAnalysisPropertyProvider[] providers)
+        {
+            if (providers == null)
+            {
+                throw new ArgumentNullException("providers");
+            }
+
+            this.providers = providers;
+        }
+
+        #endregion
+
+        #region IAnalysisPropertyProvider interface
+
+        public IEnumerable<Property> GetAllProperties()
+        {
+            HashSet<string> allKeys = new HashSet<string>(this.providers.SelectMany(p => p.GetAllProperties().Select(s => s.Id)));
+
+            IList<Property> allProperties = new List<Property>();
+            foreach (string key in allKeys)
+            {
+                Property property;
+                bool match = this.TryGetProperty(key, out property);
+
+                Debug.Assert(match, "Expecting to find value for all keys. Key: " + key);
+                allProperties.Add(property);
+            }
+
+            return allProperties;
+        }
+
+        public bool TryGetProperty(string key, out Property property)
+        {
+            property = null;
+            bool found = false;
+
+            foreach (IAnalysisPropertyProvider current in this.providers)
+            {
+                if (current.TryGetProperty(key, out property))
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            return found;
+        }
+
+        #endregion
+    }
+}

--- a/SonarQube.Common/AnalysisProperties/AnalysisProperties.cs
+++ b/SonarQube.Common/AnalysisProperties/AnalysisProperties.cs
@@ -1,0 +1,66 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AnalysisProperties.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Data class to describe global analysis properties
+    /// /// </summary>
+    /// <remarks>The class is XML-serializable.
+    /// We want the serialized representation to be a simple list of elements so the class inherits directly from the generic List</remarks>
+    [XmlRoot(Namespace = XmlNamespace, ElementName = XmlElementName)]
+    public class AnalysisProperties : List<Property>
+    {
+        public const string XmlNamespace = ProjectInfo.XmlNamespace;
+        public const string XmlElementName = "SonarQubeAnalysisProperties";
+
+        #region Serialization
+
+        [XmlIgnore]
+        public string FilePath
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Saves the project to the specified file as XML
+        /// </summary>
+        public void Save(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException("fileName");
+            }
+
+            Serializer.SaveModel(this, fileName);
+
+            this.FilePath = fileName;
+        }
+
+        /// <summary>
+        /// Loads and returns project info from the specified XML file
+        /// </summary>
+        public static AnalysisProperties Load(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException("fileName");
+            }
+
+            AnalysisProperties model = Serializer.LoadModel<AnalysisProperties>(fileName);
+            model.FilePath = fileName;
+            return model;
+        }
+
+        #endregion
+
+    }
+}

--- a/SonarQube.Common/AnalysisProperties/AnalysisPropertyFileProvider.cs
+++ b/SonarQube.Common/AnalysisProperties/AnalysisPropertyFileProvider.cs
@@ -1,0 +1,150 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AnalysisPropertyFileProvider.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Handles locating an analysis properties file and returning the appropriate properties
+    /// </summary>
+    public class AnalysisPropertyFileProvider : IAnalysisPropertyProvider
+    {
+        private const string DescriptorId = "properties.file.argument";
+
+        public static readonly ArgumentDescriptor Descriptor = new ArgumentDescriptor(DescriptorId, new string[] { "/s:" }, false, Resources.CmdLine_ArgDescription_PropertiesFilePath, false);
+
+        public const string DefaultFileName = "SonarQube.Analysis.xml";
+
+        private readonly AnalysisProperties propertiesFile;
+
+        #region Public methods
+
+        /// <summary>
+        /// Attempts to construct and return a file-based properties provider
+        /// </summary>
+        /// <param name="defaultPropertiesFileDirectory">Directory in which to look for the default properties file (optional)</param>
+        /// <param name="commandLineArguments">List of command line arguments (optional)</param>
+        /// <returns>False if errors occurred when constructing the provider, otherwise true</returns>
+        /// <remarks>If a properties file could not be located then an empty provider will be returned</remarks>
+        public static bool TryCreateProvider(IEnumerable<ArgumentInstance> commandLineArguments, string defaultPropertiesFileDirectory, ILogger logger, out AnalysisPropertyFileProvider provider)
+        {
+            if (commandLineArguments == null)
+            {
+                throw new ArgumentNullException("commandLineArguments");
+            }
+            if (string.IsNullOrWhiteSpace(defaultPropertiesFileDirectory))
+            {
+                throw new ArgumentNullException("defaultDirectory");
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
+            }
+
+            // If the path to a properties file was specified on the command line, use that.
+            // Otherwise, look for a default properties file in the default directory.
+
+            string propertiesFilePath;
+            ArgumentInstance.TryGetArgumentValue(DescriptorId, commandLineArguments, out propertiesFilePath);
+
+            AnalysisProperties locatedPropertiesFile;
+            if (TryGetPropertiesFile(propertiesFilePath, defaultPropertiesFileDirectory, logger, out locatedPropertiesFile) && locatedPropertiesFile != null)
+            {
+                provider = new AnalysisPropertyFileProvider(locatedPropertiesFile);
+                return true;
+            }
+
+            provider = null;
+            return false;
+        }
+
+        public AnalysisProperties PropertiesFile {  get { return this.propertiesFile; } }
+
+        #endregion
+
+        #region IAnalysisPropertyProvider methods
+
+        public IEnumerable<Property> GetAllProperties()
+        {
+            return this.propertiesFile ?? Enumerable.Empty<Property>();
+        }
+
+        public bool TryGetProperty(string key, out Property property)
+        {
+            return Property.TryGetProperty(key, this.propertiesFile, out property);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private AnalysisPropertyFileProvider(AnalysisProperties properties)
+        {
+            if (properties == null)
+            {
+                throw new ArgumentNullException("properties");
+            }
+            this.propertiesFile = properties;
+        }
+
+        /// <summary>
+        /// Attempt to find a properties file - either the one specified by the user, or the default properties file.
+        /// Returns false if a path is specified to a file that does not exist, otherwise returns true.
+        /// </summary>
+        private static bool TryGetPropertiesFile(string propertiesFilePath, string defaultPropertiesFileDirectory, ILogger logger, out AnalysisProperties properties)
+        {
+            properties = null;
+            bool isValid = true;
+
+            string resolvedPath = propertiesFilePath ?? TryGetDefaultPropertiesFilePath(defaultPropertiesFileDirectory, logger);
+
+            if (resolvedPath != null)
+            {
+                if (File.Exists(resolvedPath))
+                {
+                    try
+                    {
+                        logger.LogMessage(Resources.DIAG_Properties_LoadingPropertiesFromFile, resolvedPath);
+                        properties = AnalysisProperties.Load(resolvedPath);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        logger.LogError(Resources.ERROR_Properties_InvalidPropertiesFile, resolvedPath);
+                        isValid = false;
+                    }
+                }
+                else
+                {
+                    logger.LogError(Resources.ERROR_Properties_GlobalPropertiesFileDoesNotExist, resolvedPath);
+                }
+            }
+            return isValid;
+        }
+
+        private static string TryGetDefaultPropertiesFilePath(string defaultDirectory, ILogger logger)
+        {
+            string fullPath = Path.Combine(defaultDirectory, DefaultFileName);
+            if (File.Exists(fullPath))
+            {
+                logger.LogMessage(Resources.DIAG_Properties_DefaultPropertiesFileFound, fullPath);
+                return fullPath;
+            }
+            else
+            {
+                logger.LogMessage(Resources.DIAG_Properties_DefaultPropertiesFileNotFound, fullPath);
+
+                return null;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/SonarQube.Common/AnalysisProperties/CmdLineArgPropertyProvider.cs
+++ b/SonarQube.Common/AnalysisProperties/CmdLineArgPropertyProvider.cs
@@ -1,0 +1,159 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CmdLineArgPropertyProvider.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Handles validating and fetch analysis properties from the command line
+    /// </summary>
+    public class CmdLineArgPropertyProvider : IAnalysisPropertyProvider
+    {
+        public const string DynamicPropertyArgumentId = "dynamic.property";
+
+        public static readonly ArgumentDescriptor Descriptor = new ArgumentDescriptor(
+            id: DynamicPropertyArgumentId, prefixes: new string[] { "/p:" }, required: false, allowMultiple: true, description: Resources.CmdLine_ArgDescription_DynamicProperty);
+
+        private readonly IEnumerable<Property> properties;
+           
+        #region Public methods
+
+        /// <summary>
+        /// Attempts to construct and return a provider that uses analysis properties provided on the command line
+        /// </summary>
+        /// <param name="commandLineArguments">List of command line arguments (optional)</param>
+        /// <returns>False if errors occurred when constructing the provider, otherwise true</returns>
+        /// <remarks>If no properties were provided on the command line then an empty provider will be returned</remarks>
+        public static bool TryCreateProvider(IEnumerable<ArgumentInstance> commandLineArguments, ILogger logger, out CmdLineArgPropertyProvider provider)
+        {
+            if (commandLineArguments == null)
+            {
+                throw new ArgumentNullException("commandLineArguments");
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
+            }
+
+            IEnumerable<Property> validProperties;
+            if (TryGetAnalysisProperties(commandLineArguments, logger, out validProperties))
+            {
+                provider = new CmdLineArgPropertyProvider(validProperties);
+                return true;
+            }
+
+            provider = null;
+            return false;
+        }
+
+        #endregion
+
+
+        #region IAnalysisPropertyProvider interface
+
+        public bool TryGetProperty(string key, out Property property)
+        {
+            return Property.TryGetProperty(key, this.properties, out property);
+        }
+           
+        public IEnumerable<Property> GetAllProperties()
+        {
+            return this.properties ?? Enumerable.Empty<Property>();
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private CmdLineArgPropertyProvider(IEnumerable<Property> properties)
+        {
+            if (properties == null)
+            {
+                throw new ArgumentNullException("properties");
+            }
+            this.properties = properties;
+        }
+
+        #endregion
+
+        #region Analysis properties handling
+        /*
+            Analysis properties (/p:[key]=[value] arguments) need further processing.
+            We need to extract the key-value pairs and check for duplicate keys
+        */
+
+        private static bool TryGetAnalysisProperties(IEnumerable<ArgumentInstance> arguments, ILogger logger, out IEnumerable<Property> analysisProperties)
+        {
+            bool success = true;
+
+            List<Property> validProperties = new List<Property>();
+
+            foreach (ArgumentInstance argument in arguments.Where(a => a.Descriptor.Id == DynamicPropertyArgumentId))
+            {
+                Property property;
+                if (Property.TryParse(argument.Value, out property))
+                {
+                    Property existing;
+                    if (Property.TryGetProperty(property.Id, validProperties, out existing))
+                    {
+                        logger.LogError(Resources.ERROR_CmdLine_DuplicateProperty, argument.Value, existing.Value);
+                        success = false;
+                    }
+                    else
+                    {
+                        validProperties.Add(property);
+                    }
+                }
+                else
+                {
+                    logger.LogError(Resources.ERROR_CmdLine_InvalidAnalysisProperty, argument.Value);
+                    success = false;
+                }
+            }
+
+            // Check for named parameters that can't be set by dynamic properties
+            success = success & !ContainsNamedParameter(SonarProperties.ProjectKey, validProperties, logger, Resources.ERROR_CmdLine_MustUseProjectKey);
+            success = success & !ContainsNamedParameter(SonarProperties.ProjectName, validProperties, logger, Resources.ERROR_CmdLine_MustUseProjectName);
+            success = success & !ContainsNamedParameter(SonarProperties.ProjectVersion, validProperties, logger, Resources.ERROR_CmdLine_MustUseProjectVersion);
+
+            // Check for others properties that can't be set
+            success = success & !ContainsUnsettableParameter(SonarProperties.ProjectBaseDir, validProperties, logger);
+            success = success & !ContainsUnsettableParameter(SonarProperties.WorkingDirectory, validProperties, logger);
+
+            analysisProperties = validProperties;
+            return success;
+        }
+        
+        private static bool ContainsNamedParameter(string propertyName, IEnumerable<Property> properties, ILogger logger, string errorMessage)
+        {
+            Property existing;
+            if (Property.TryGetProperty(propertyName, properties, out existing))
+            {
+                logger.LogError(errorMessage);
+                return true;
+            }
+            return false;
+        }
+
+        private static bool ContainsUnsettableParameter(string propertyName, IEnumerable<Property> properties, ILogger logger)
+        {
+            Property existing;
+            if (Property.TryGetProperty(propertyName, properties, out existing))
+            {
+                logger.LogError(Resources.ERROR_CmdLine_CannotSetPropertyOnCommandLine, propertyName);
+                return true;
+            }
+            return false;
+        }
+
+        #endregion
+
+    }
+}

--- a/SonarQube.Common/AnalysisProperties/IAnalysisPropertyProvider.cs
+++ b/SonarQube.Common/AnalysisProperties/IAnalysisPropertyProvider.cs
@@ -1,0 +1,53 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IAnalysisPropertyProvider.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Provides analysis property properties
+    /// </summary>
+    /// <remarks>The properties could come from different sources e.g. a file, command line arguments, the SonarQube server</remarks>
+    public interface IAnalysisPropertyProvider
+    {
+        IEnumerable<Property> GetAllProperties();
+
+        bool TryGetProperty(string key, out Property property);
+    }
+
+    public static class AnalysisPropertyProviderExtensions
+    {
+        public static bool TryGetValue(this IAnalysisPropertyProvider provider, string name, out string value)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException("provider");
+            }
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException("name");
+            }
+
+            Property property;
+            if (provider.TryGetProperty(name, out property))
+            {
+                value = property.Value;
+                return true;
+            }
+            else
+            {
+                value = null;
+                return false;
+            }
+        }
+    }
+}

--- a/SonarQube.Common/AnalysisProperties/Property.cs
+++ b/SonarQube.Common/AnalysisProperties/Property.cs
@@ -1,0 +1,99 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Property.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Serialization;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Data class to describe an additional analysis configuration property
+    /// /// </summary>
+    /// <remarks>The class is XML-serializable</remarks>
+    public class Property
+    {
+        #region Data
+
+        /// <summary>
+        /// The identifier for the property
+        /// </summary>
+        /// <remarks>Each type </remarks>
+        [XmlAttribute("Name")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The value of the property
+        /// </summary>
+        [XmlText]
+        public string Value { get; set; }
+
+        #endregion
+
+        #region Static helper methods
+        
+        //TODO: this expression only works for single-line values
+        // Regular expression pattern: we're looking for matches that:
+        // * start at the beginning of a line
+        // * start with a character or number
+        // * are in the form [key]=[value],
+        // * where [key] can  
+        //   - starts with an alpanumeric character.
+        //   - can be followed by any number of alphanumeric characters or .
+        //   - whitespace is not allowed
+        // * [value] can contain anything
+        public const string KeyValuePropertyPattern = @"^(?<key>\w[\w\d\.-]*)=(?<value>[^\r\n]+)";
+
+        private static readonly Regex SingleLinePropertyRegEx = new Regex(KeyValuePropertyPattern, RegexOptions.Compiled);
+        
+        /// <summary>
+        /// Attempts to parse the supplied string into a key and value
+        /// </summary>
+        public static bool TryParse(string input, out Property property)
+        {
+            property = null;
+
+            Match match = SingleLinePropertyRegEx.Match(input);
+
+            if (match.Success)
+            {
+                string key = match.Groups["key"].Value;
+                string value = match.Groups["value"].Value;
+
+                property = new Property() { Id = key, Value = value };
+            }
+            return property != null;
+        }
+
+        /// <summary>
+        /// Comparer to use when comparing keys of analysis properties
+        /// </summary>
+        public static readonly IEqualityComparer<string> PropertyKeyComparer = StringComparer.Ordinal;
+
+        /// <summary>
+        /// Returns the first property with the supplied key, or null if there is no match
+        /// </summary>
+        public static bool TryGetProperty(string key, IEnumerable<Property> properties, out Property property)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException("key");
+            }
+            if (properties == null)
+            {
+                throw new ArgumentNullException("properties");
+            }
+
+            property = properties.FirstOrDefault(s => Property.PropertyKeyComparer.Equals(s.Id, key));
+            return property != null;
+        }
+
+        #endregion
+    }
+}

--- a/SonarQube.Common/CommandLine/ArgumentDescriptor.cs
+++ b/SonarQube.Common/CommandLine/ArgumentDescriptor.cs
@@ -14,6 +14,8 @@ namespace SonarQube.Common
     /// </summary>
     public class ArgumentDescriptor
     {
+        public static readonly StringComparer IdComparer = StringComparer.InvariantCultureIgnoreCase;
+
         private readonly string id;
         private readonly string[] prefixes;
         private readonly bool required;

--- a/SonarQube.Common/CommandLine/ArgumentInstance.cs
+++ b/SonarQube.Common/CommandLine/ArgumentInstance.cs
@@ -6,6 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SonarQube.Common
 {
@@ -27,8 +29,56 @@ namespace SonarQube.Common
             this.value = value;
         }
 
+        #region Data
+
         public ArgumentDescriptor Descriptor { get { return this.descriptor; } }
 
         public string Value { get { return this.value; } }
+
+
+        #endregion
+
+        #region Static methods
+
+        public static bool TryGetArgument(string id, IEnumerable<ArgumentInstance> arguments, out ArgumentInstance instance)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentNullException("id");
+            }
+            if (arguments == null)
+            {
+                throw new ArgumentNullException("arguments");
+            }
+
+            instance = arguments.FirstOrDefault(a => ArgumentDescriptor.IdComparer.Equals(a.Descriptor.Id, id));
+            return instance != null;
+        }
+
+        public static bool TryGetArgumentValue(string id, IEnumerable<ArgumentInstance> arguments, out string value)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentNullException("id");
+            }
+            if (arguments == null)
+            {
+                throw new ArgumentNullException("arguments");
+            }
+
+            ArgumentInstance instance;
+            if (TryGetArgument(id, arguments, out instance))
+            {
+                value = instance.value;
+            }
+            else
+            {
+                value = null;
+            }
+
+            return instance != null;
+        }
+
+        #endregion
     }
 }

--- a/SonarQube.Common/Resources.Designer.cs
+++ b/SonarQube.Common/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /p:[key]=[value].
+        /// </summary>
+        internal static string CmdLine_ArgDescription_DynamicProperty {
+            get {
+                return ResourceManager.GetString("CmdLine_ArgDescription_DynamicProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [/s:{full path to the analysis settings file}].
+        /// </summary>
+        internal static string CmdLine_ArgDescription_PropertiesFilePath {
+            get {
+                return ResourceManager.GetString("CmdLine_ArgDescription_PropertiesFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Commencing retry-able operation. Max wait (milliseconds): {0}, pause between tries (milliseconds): {1}.
         /// </summary>
         internal static string DIAG_BeginningRetry {
@@ -128,6 +146,33 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Default properties file was found at {0}.
+        /// </summary>
+        internal static string DIAG_Properties_DefaultPropertiesFileFound {
+            get {
+                return ResourceManager.GetString("DIAG_Properties_DefaultPropertiesFileFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default properties file was not found at {0}.
+        /// </summary>
+        internal static string DIAG_Properties_DefaultPropertiesFileNotFound {
+            get {
+                return ResourceManager.GetString("DIAG_Properties_DefaultPropertiesFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Loading analysis properties from {0}.
+        /// </summary>
+        internal static string DIAG_Properties_LoadingPropertiesFromFile {
+            get {
+                return ResourceManager.GetString("DIAG_Properties_LoadingPropertiesFromFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Retrying....
         /// </summary>
         internal static string DIAG_RetryingOperation {
@@ -155,11 +200,38 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The property &apos;{0}&apos; is automatically set by the MSBuild Runner and cannot be overridden on the command line..
+        /// </summary>
+        internal static string ERROR_CmdLine_CannotSetPropertyOnCommandLine {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_CannotSetPropertyOnCommandLine", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A value has already been supplied for this argument:{0}. Existing: {1}.
         /// </summary>
         internal static string ERROR_CmdLine_DuplicateArg {
             get {
                 return ResourceManager.GetString("ERROR_CmdLine_DuplicateArg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A value has already been supplied for this property. Key: {0}, existing value: {1}.
+        /// </summary>
+        internal static string ERROR_CmdLine_DuplicateProperty {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_DuplicateProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The format of the analysis property {0} is invalid.
+        /// </summary>
+        internal static string ERROR_CmdLine_InvalidAnalysisProperty {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_InvalidAnalysisProperty", resourceCulture);
             }
         }
         
@@ -173,11 +245,56 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please use the parameter prefix &apos;/k:&apos; to define the key of the SonarQube project instead of injecting this key with the help of the &apos;sonar.projectKey&apos; property..
+        /// </summary>
+        internal static string ERROR_CmdLine_MustUseProjectKey {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_MustUseProjectKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please use the parameter prefix &apos;/n:&apos; to define the name of the SonarQube project instead of injecting this name with the help of the &apos;sonar.projectName&apos; property..
+        /// </summary>
+        internal static string ERROR_CmdLine_MustUseProjectName {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_MustUseProjectName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please use the parameter prefix &apos;/v:&apos; to define the version of the SonarQube project instead of injecting this version with the help of the &apos;sonar.projectVersion&apos; property..
+        /// </summary>
+        internal static string ERROR_CmdLine_MustUseProjectVersion {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_MustUseProjectVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unrecognised command line argument: {0}.
         /// </summary>
         internal static string ERROR_CmdLine_UnrecognisedArg {
             get {
                 return ResourceManager.GetString("ERROR_CmdLine_UnrecognisedArg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find the SonarQube analysis settings file &apos;{0}&apos;. Please fix the path to this settings file..
+        /// </summary>
+        internal static string ERROR_Properties_GlobalPropertiesFileDoesNotExist {
+            get {
+                return ResourceManager.GetString("ERROR_Properties_GlobalPropertiesFileDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to read the SonarQube analysis settings file &apos;{0}&apos;. Please fix the content of this file..
+        /// </summary>
+        internal static string ERROR_Properties_InvalidPropertiesFile {
+            get {
+                return ResourceManager.GetString("ERROR_Properties_InvalidPropertiesFile", resourceCulture);
             }
         }
         

--- a/SonarQube.Common/Resources.resx
+++ b/SonarQube.Common/Resources.resx
@@ -169,4 +169,43 @@
   <data name="ERROR_CmdLine_UnrecognisedArg" xml:space="preserve">
     <value>Unrecognised command line argument: {0}</value>
   </data>
+  <data name="CmdLine_ArgDescription_PropertiesFilePath" xml:space="preserve">
+    <value>[/s:{full path to the analysis settings file}]</value>
+  </data>
+  <data name="DIAG_Properties_DefaultPropertiesFileFound" xml:space="preserve">
+    <value>Default properties file was found at {0}</value>
+  </data>
+  <data name="DIAG_Properties_DefaultPropertiesFileNotFound" xml:space="preserve">
+    <value>Default properties file was not found at {0}</value>
+  </data>
+  <data name="DIAG_Properties_LoadingPropertiesFromFile" xml:space="preserve">
+    <value>Loading analysis properties from {0}</value>
+  </data>
+  <data name="ERROR_Properties_GlobalPropertiesFileDoesNotExist" xml:space="preserve">
+    <value>Unable to find the SonarQube analysis settings file '{0}'. Please fix the path to this settings file.</value>
+  </data>
+  <data name="ERROR_Properties_InvalidPropertiesFile" xml:space="preserve">
+    <value>Unable to read the SonarQube analysis settings file '{0}'. Please fix the content of this file.</value>
+  </data>
+  <data name="CmdLine_ArgDescription_DynamicProperty" xml:space="preserve">
+    <value>/p:[key]=[value]</value>
+  </data>
+  <data name="ERROR_CmdLine_CannotSetPropertyOnCommandLine" xml:space="preserve">
+    <value>The property '{0}' is automatically set by the MSBuild Runner and cannot be overridden on the command line.</value>
+  </data>
+  <data name="ERROR_CmdLine_DuplicateProperty" xml:space="preserve">
+    <value>A value has already been supplied for this property. Key: {0}, existing value: {1}</value>
+  </data>
+  <data name="ERROR_CmdLine_InvalidAnalysisProperty" xml:space="preserve">
+    <value>The format of the analysis property {0} is invalid</value>
+  </data>
+  <data name="ERROR_CmdLine_MustUseProjectKey" xml:space="preserve">
+    <value>Please use the parameter prefix '/k:' to define the key of the SonarQube project instead of injecting this key with the help of the 'sonar.projectKey' property.</value>
+  </data>
+  <data name="ERROR_CmdLine_MustUseProjectName" xml:space="preserve">
+    <value>Please use the parameter prefix '/n:' to define the name of the SonarQube project instead of injecting this name with the help of the 'sonar.projectName' property.</value>
+  </data>
+  <data name="ERROR_CmdLine_MustUseProjectVersion" xml:space="preserve">
+    <value>Please use the parameter prefix '/v:' to define the version of the SonarQube project instead of injecting this version with the help of the 'sonar.projectVersion' property.</value>
+  </data>
 </root>

--- a/SonarQube.Common/Serializer.cs
+++ b/SonarQube.Common/Serializer.cs
@@ -50,7 +50,7 @@ namespace SonarQube.Common
         }
 
         /// <summary>
-        /// Loads and returns an instnace of <typeparamref name="T"/> from the specified XML file
+        /// Loads and returns an instance of <typeparamref name="T"/> from the specified XML file
         /// </summary>
         public static T LoadModel<T>(string fileName)
         {

--- a/SonarQube.Common/SonarQube.Common.csproj
+++ b/SonarQube.Common/SonarQube.Common.csproj
@@ -68,6 +68,12 @@
     </Compile>
     <Compile Include="Serializer.cs" />
     <Compile Include="AnalysisConfig\AnalysisConfig.cs" />
+    <Compile Include="AnalysisProperties\AggregatePropertiesProvider.cs" />
+    <Compile Include="AnalysisProperties\AnalysisProperties.cs" />
+    <Compile Include="AnalysisProperties\CmdLineArgPropertyProvider.cs" />
+    <Compile Include="AnalysisProperties\AnalysisPropertyFileProvider.cs" />
+    <Compile Include="AnalysisProperties\IAnalysisPropertyProvider.cs" />
+    <Compile Include="AnalysisProperties\Property.cs" />
     <Compile Include="SonarProperties.cs" />
     <Compile Include="Utilities.cs" />
   </ItemGroup>

--- a/Tests/SonarQube.Common.UnitTests/AggregatePropertiesProviderTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/AggregatePropertiesProviderTests.cs
@@ -1,0 +1,113 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AggregatePropertiesProviderTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TestUtilities;
+
+namespace SonarQube.Common.UnitTests
+{
+    [TestClass]
+    public class AggregatePropertiesProviderTests
+    {
+        public TestContext TestContext { get; set; }
+
+        #region Tests
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void AggProperties_NullOrEmptyList()
+        {
+            // 1. Null -> error
+            AssertException.Expects<ArgumentNullException>(() => new AggregatePropertiesProvider(null));
+
+            // 2. Empty list of providers -> valid but returns nothing
+            AggregatePropertiesProvider provider = new AggregatePropertiesProvider(new IAnalysisPropertyProvider[] { });
+
+            Assert.AreEqual(0, provider.GetAllProperties().Count());
+            Property actualProperty;
+            bool success = provider.TryGetProperty("any key", out actualProperty);
+
+            Assert.IsFalse(success, "Not expecting a property to be returned");
+            Assert.IsNull(actualProperty, "Returned property should be null");
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void AggProperties_Aggregation()
+        {
+            // Checks the aggregation works as expected
+
+            // 0. Setup
+            ListPropertiesProvider provider1 = new ListPropertiesProvider();
+            provider1.AddProperty("shared.key.A", "value A from one");
+            provider1.AddProperty("shared.key.B", "value B from one");
+            provider1.AddProperty("p1.unique.key.1", "p1 unique value 1");
+
+            ListPropertiesProvider provider2 = new ListPropertiesProvider();
+            provider2.AddProperty("shared.key.A", "value A from two");
+            provider2.AddProperty("shared.key.B", "value B from two");
+            provider2.AddProperty("p2.unique.key.1", "p2 unique value 1");
+
+            ListPropertiesProvider provider3 = new ListPropertiesProvider();
+            provider3.AddProperty("shared.key.A", "value A from three"); // this provider only has one of the shared values
+            provider3.AddProperty("p3.unique.key.1", "p3 unique value 1");
+
+
+            // 1. Ordering
+            AggregatePropertiesProvider aggProvider = new AggregatePropertiesProvider(provider1, provider2, provider3);
+
+            AssertSettingsCount(5, aggProvider);
+
+            AssertPropertyValue("shared.key.A", "value A from one", aggProvider);
+            AssertPropertyValue("shared.key.B", "value B from one", aggProvider);
+
+            AssertPropertyValue("p1.unique.key.1", "p1 unique value 1", aggProvider);
+            AssertPropertyValue("p2.unique.key.1", "p2 unique value 1", aggProvider);
+            AssertPropertyValue("p3.unique.key.1", "p3 unique value 1", aggProvider);
+
+            // 2. Reverse the order and try again
+            aggProvider = new AggregatePropertiesProvider(provider3, provider2, provider1);
+
+            AssertSettingsCount(5, aggProvider);
+
+            AssertPropertyValue("shared.key.A", "value A from three", aggProvider);
+            AssertPropertyValue("shared.key.B", "value B from two", aggProvider);
+
+            AssertPropertyValue("p1.unique.key.1", "p1 unique value 1", aggProvider);
+            AssertPropertyValue("p2.unique.key.1", "p2 unique value 1", aggProvider);
+            AssertPropertyValue("p3.unique.key.1", "p3 unique value 1", aggProvider);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        #endregion
+
+        #region Checks
+
+        private static void AssertSettingsCount(int expected, IAnalysisPropertyProvider provider)
+        {
+            IEnumerable<Property> allProperties = provider.GetAllProperties();
+            Assert.IsNotNull(allProperties, "Returned list of properties should not be null");
+            Assert.AreEqual(expected, allProperties.Count(), "Unexpected number of properties returned");
+        }
+
+        private static void AssertPropertyValue(string key, string expectedValue, IAnalysisPropertyProvider actualProvider)
+        {
+            Property actualProperty;
+            bool exists = actualProvider.TryGetProperty(key, out actualProperty);
+            Assert.IsTrue(exists, "Specified property does not exist. Key: {0}", key);
+            Assert.AreEqual(expectedValue, actualProperty.Value, "Property does not have the expected value. Key: {0}", key);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/SonarQube.Common.UnitTests/AnalysisPropertyFileProviderTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/AnalysisPropertyFileProviderTests.cs
@@ -1,0 +1,206 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AnalysisPropertyFileProviderTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TestUtilities;
+
+namespace SonarQube.Common.UnitTests
+{
+    [TestClass]
+    public class AnalysisPropertyFileProviderTests
+    {
+        private static readonly ArgumentDescriptor DummyDescriptor = new ArgumentDescriptor("dummy", new string[] { "dummy predifx" }, false, "dummy desc", true);
+
+        public TestContext TestContext { get; set; }
+
+        #region Tests
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void FileProvider_InvalidArguments()
+        {
+            // 0. Setup
+            AnalysisPropertyFileProvider provider;
+
+            // 1. Null command line arguments
+            AssertException.Expects<ArgumentNullException>(() => AnalysisPropertyFileProvider.TryCreateProvider(null, string.Empty, new TestLogger(), out provider));
+
+            // 2. Null directory
+            AssertException.Expects<ArgumentNullException>(() => AnalysisPropertyFileProvider.TryCreateProvider(Enumerable.Empty<ArgumentInstance>(), null, new TestLogger(), out provider));
+
+            // 3. Null logger
+            AssertException.Expects<ArgumentNullException>(() => AnalysisPropertyFileProvider.TryCreateProvider(Enumerable.Empty<ArgumentInstance>(), string.Empty, null, out provider));
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void FileProvider_UseDefaultPropertiesFile()
+        {
+            // Arrange
+            string defaultPropertiesDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            string validPropertiesFile = CreateValidPropertiesFile(defaultPropertiesDir, AnalysisPropertyFileProvider.DefaultFileName);
+            TestLogger logger = new TestLogger();
+
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+
+            // Act
+            AnalysisPropertyFileProvider provider = InitializeAndCheckIsValid(defaultPropertiesDir, args, logger);
+
+            // Assert
+            AssertExpectedPropertiesFile(validPropertiesFile, provider, logger);
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void FileProvider_UseSpecifiedPropertiesFile()
+        {
+            // Arrange
+            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            string validPropertiesFile = CreateValidPropertiesFile(testDir, "myPropertiesFile.xml");
+
+            string defaultPropertiesDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "Default");
+            CreateFile(defaultPropertiesDir, AnalysisPropertyFileProvider.DefaultFileName, "invalid file - will error if this file is loaded");
+
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+
+            args.Add(new ArgumentInstance(AnalysisPropertyFileProvider.Descriptor, validPropertiesFile));
+
+            TestLogger logger = new TestLogger();
+
+            // Act
+            AnalysisPropertyFileProvider provider = InitializeAndCheckIsValid(defaultPropertiesDir, args, logger);
+
+            // Assert
+            AssertExpectedPropertiesFile(validPropertiesFile, provider, logger);
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void FileProvider_MissingPropertiesFile()
+        {
+            // Arrange
+            TestLogger logger = new TestLogger();
+
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+            args.Add(new ArgumentInstance(AnalysisPropertyFileProvider.Descriptor, "missingFile.txt"));
+
+            // Act
+            AnalysisPropertyFileProvider provider;
+            bool success = AnalysisPropertyFileProvider.TryCreateProvider(args, this.TestContext.DeploymentDirectory, logger, out provider);
+
+            // Assert
+            Assert.IsFalse(success, "Not expecting the properties provider to be created successfully");
+            logger.AssertErrorsLogged(1);
+            logger.AssertSingleErrorExists("missingFile.txt");
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void FileProvider_InvalidDefaultPropertiesFile()
+        {
+            // Arrange
+            TestLogger logger = new TestLogger();
+            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            string invalidFile = CreateFile(testDir, AnalysisPropertyFileProvider.DefaultFileName, "not a valid XML properties file");
+
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+
+            // Act
+            AnalysisPropertyFileProvider provider;
+            bool success = AnalysisPropertyFileProvider.TryCreateProvider(args, testDir, logger, out provider);
+
+            // Assert
+            Assert.IsFalse(success, "Not expecting the properties provider to be created successfully");
+            logger.AssertErrorsLogged(1);
+            logger.AssertSingleErrorExists(invalidFile);
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void FileProvider_InvalidSpecifiedPropertiesFile()
+        {
+            // Arrange
+            TestLogger logger = new TestLogger();
+            string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            string invalidFile = CreateFile(testDir, "invalidPropertiesFile.txt", "not a valid XML properties file");
+
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+            args.Add(new ArgumentInstance(AnalysisPropertyFileProvider.Descriptor, invalidFile));
+
+            // Act
+            AnalysisPropertyFileProvider provider;
+            bool success = AnalysisPropertyFileProvider.TryCreateProvider(args, testDir, logger, out provider);
+
+            // Assert
+            Assert.IsFalse(success, "Not expecting the properties provider to be created successfully");
+            logger.AssertErrorsLogged(1);
+            logger.AssertSingleErrorExists(invalidFile);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private static string CreateFile(string path, string fileName, string content)
+        {
+            string fullPath = Path.Combine(path, fileName);
+            File.WriteAllText(fullPath, string.Empty);
+            return fullPath;
+        }
+
+        private static string CreateValidPropertiesFile(string path, string fileName)
+        {
+            string fullPath = Path.Combine(path, fileName);
+
+            AnalysisProperties properties = new AnalysisProperties();
+
+            properties = new AnalysisProperties();
+            properties.Add(new Property() { Id = "foo", Value = "bar" });
+
+            properties.Save(fullPath);
+            return fullPath;
+        }
+
+        private static void AddProperty(IList<Property> properties, string key, string value)
+        {
+            properties.Add(new Property() { Id = key, Value = value });
+        }
+
+        #endregion
+
+        #region Checks
+
+        private static AnalysisPropertyFileProvider InitializeAndCheckIsValid(string defaultPropertiesDirectory, IEnumerable<ArgumentInstance> cmdLineArgs, ILogger logger)
+        {
+            AnalysisPropertyFileProvider provider;
+            bool isValid = AnalysisPropertyFileProvider.TryCreateProvider(cmdLineArgs, defaultPropertiesDirectory, logger, out provider);
+            
+            Assert.IsTrue(isValid, "Expecting the provider to be initialized successfully");
+            return provider;
+        }
+
+        private static void AssertExpectedPropertiesFile(string expectedFilePath, AnalysisPropertyFileProvider actualProvider, TestLogger logger)
+        {
+            Assert.IsNotNull(actualProvider.PropertiesFile, "Properties file object should not be null");
+            Assert.AreEqual(expectedFilePath, actualProvider.PropertiesFile.FilePath, "Properties were not loaded from the expected location");
+        }
+
+        private static void AssertPropertyExists(string key, string expectedValue, IAnalysisPropertyProvider actualProvider)
+        {
+            Property actualProperty;
+            bool exists = actualProvider.TryGetProperty(key, out actualProperty);
+            Assert.IsTrue(exists, "Specified property does not exist. Key: {0}", key);
+            Assert.AreEqual(expectedValue, actualProperty.Value, "Property does not have the expected value. Key: {0}", key);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/SonarQube.Common.UnitTests/CmdLineArgsPropertiesProviderTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/CmdLineArgsPropertiesProviderTests.cs
@@ -1,0 +1,188 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CmdLineArgsPropertiesProviderTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TestUtilities;
+
+namespace SonarQube.Common.UnitTests
+{
+    [TestClass]
+    public class CmdLineArgsPropertiesProviderTests
+    {
+        public TestContext TestContext { get; set; }
+
+        #region Tests
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void CmdLineArgProperties_InvalidArguments()
+        {
+            CmdLineArgPropertyProvider provider;
+
+            AssertException.Expects<ArgumentNullException>(() => CmdLineArgPropertyProvider.TryCreateProvider(null, new TestLogger(), out provider));
+            AssertException.Expects<ArgumentNullException>(() => CmdLineArgPropertyProvider.TryCreateProvider(Enumerable.Empty<ArgumentInstance>(), null, out provider));
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void CmdLineArgProperties_DynamicProperties()
+        {
+            // 0. Arrange
+            TestLogger logger = new TestLogger();
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+
+            ArgumentDescriptor dummyDescriptor = new ArgumentDescriptor("dummy", new string[] { "dummy prefix" }, false, "dummy desc", true);
+            ArgumentDescriptor dummyDescriptor2 = new ArgumentDescriptor("dummy2", new string[] { "dummy prefix 2" }, false, "dummy desc 2", true);
+
+            args.Add(new ArgumentInstance(dummyDescriptor, "should be ignored"));
+            args.Add(new ArgumentInstance(dummyDescriptor2, "should be ignored"));
+
+            AddDynamicArguments(args, "key1=value1", "key2=value two with spaces");
+
+            // Act
+            CmdLineArgPropertyProvider provider;
+            bool success = CmdLineArgPropertyProvider.TryCreateProvider(args, logger, out provider);
+
+            // Assert
+            Assert.IsTrue(success, "Expecting processing to succeed");
+            
+            AssertPropertyHasValue("key1", "value1", provider);
+            AssertPropertyHasValue("key2", "value two with spaces", provider);
+
+            AssertExpectedSettingCount(2, provider);
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void CmdLineArgProperties_DynamicProperties_Invalid()
+        {
+            // Arrange
+            // Act 
+            TestLogger logger = CheckProcessingFails(
+                    "invalid1 =aaa",
+                    "notkeyvalue",
+                    " spacebeforekey=bb",
+                    "missingvalue=",
+                    "validkey=validvalue");
+
+            // Assert
+            logger.AssertSingleErrorExists("invalid1 =aaa");
+            logger.AssertSingleErrorExists("notkeyvalue");
+            logger.AssertSingleErrorExists(" spacebeforekey=bb");
+            logger.AssertSingleErrorExists("missingvalue=");
+
+            logger.AssertErrorsLogged(4);
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void CmdLineArgProperties_DynamicProperties_Duplicates()
+        {
+            // Arrange
+            // Act 
+            TestLogger logger = CheckProcessingFails(
+                    "dup1=value1", "dup1=value2",
+                    "dup2=value3", "dup2=value4",
+                    "unique=value5");
+
+            // Assert
+            logger.AssertSingleErrorExists("dup1=value2", "value1");
+            logger.AssertSingleErrorExists("dup2=value4", "value3");
+            logger.AssertErrorsLogged(2);
+        }
+
+        [TestMethod]
+        [TestCategory("Properties")]
+        public void CmdLineArgProperties_Disallowed_DynamicProperties()
+        {
+            // 0. Setup
+            TestLogger logger;
+
+            // 1. Named arguments cannot be overridden
+            logger = CheckProcessingFails(
+                "sonar.projectKey=value1");
+            logger.AssertSingleErrorExists(SonarProperties.ProjectKey, "/k");
+
+
+            logger = CheckProcessingFails(
+                "sonar.projectName=value1");
+            logger.AssertSingleErrorExists(SonarProperties.ProjectName, "/n");
+
+
+            logger = CheckProcessingFails(
+                "sonar.projectVersion=value1");
+            logger.AssertSingleErrorExists(SonarProperties.ProjectVersion, "/v");
+
+
+            // 2. Other values that can't be set
+            logger = CheckProcessingFails(
+                "sonar.projectBaseDir=value1");
+            logger.AssertSingleErrorExists(SonarProperties.ProjectBaseDir);
+
+
+            logger = CheckProcessingFails(
+                "sonar.working.directory=value1");
+            logger.AssertSingleErrorExists(SonarProperties.WorkingDirectory);
+
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private static void AddDynamicArguments(IList<ArgumentInstance> args, params string[] argValues)
+        {
+            foreach(string argValue in argValues)
+            {
+                args.Add(new ArgumentInstance(CmdLineArgPropertyProvider.Descriptor, argValue));
+            }
+        }
+
+        #endregion
+
+        #region Checks
+
+        private static void AssertPropertyHasValue(string key, string expectedValue, IAnalysisPropertyProvider actualProvider)
+        {
+            Property actualProperty;
+            bool success = actualProvider.TryGetProperty(key, out actualProperty);
+            Assert.IsTrue(success, "Failed to retrieve the expected setting. Key: {0}", key);
+            Assert.AreEqual(expectedValue, actualProperty.Value, "Setting does not have the expected value. Key: {0}", key);
+        }
+
+        private static void AssertExpectedSettingCount(int expected, IAnalysisPropertyProvider actualProvider)
+        {
+            IEnumerable<Property> properties = actualProvider.GetAllProperties();
+            Assert.IsNotNull(properties, "Returned properties should not be null");
+            Assert.AreEqual(expected, properties.Count(), "Unexpected number of properties");
+        }
+
+        private static TestLogger CheckProcessingFails(params string[] argValues)
+        {
+            IList<ArgumentInstance> args = new List<ArgumentInstance>();
+            AddDynamicArguments(args, argValues);
+
+            return CheckProcessingFails(args);
+        }
+
+        private static TestLogger CheckProcessingFails(IEnumerable<ArgumentInstance> args)
+        {
+            TestLogger logger = new TestLogger();
+
+            CmdLineArgPropertyProvider provider;
+            bool success = CmdLineArgPropertyProvider.TryCreateProvider(args, logger, out provider);
+            Assert.IsFalse(success, "Not expecting the provider to be created");
+            return logger;
+        }
+
+        #endregion
+
+    }
+}

--- a/Tests/SonarQube.Common.UnitTests/Infrastructure/ListSettingsProvider.cs
+++ b/Tests/SonarQube.Common.UnitTests/Infrastructure/ListSettingsProvider.cs
@@ -1,0 +1,76 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ListPropertiesProvider.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace SonarQube.Common.UnitTests
+{
+    /// <summary>
+    /// Simple settings provider that returns values from a list
+    /// </summary>
+    public class ListPropertiesProvider : IAnalysisPropertyProvider
+    {
+        private readonly IList<Property> properties;
+
+        #region Public methods
+
+        public ListPropertiesProvider()
+        {
+            this.properties = new List<Property>();
+        }
+
+        public ListPropertiesProvider(IEnumerable<Property> properties)
+        {
+            if (properties == null)
+            {
+                throw new ArgumentNullException("properties");
+            }
+
+            this.properties = new List<Property>(properties);
+        }
+
+        public Property AddProperty(string key, string value)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            Property existing;
+            if (this.TryGetProperty(key, out existing))
+            {
+                throw new ArgumentOutOfRangeException("key");
+            }
+
+            Property newProperty = new Property() { Id = key, Value = value };
+            this.properties.Add(newProperty);
+            return newProperty;
+        }
+
+        #endregion
+
+        #region IAnalysisProperiesProvider interface
+
+        public IEnumerable<Property> GetAllProperties()
+        {
+            return properties;
+        }
+
+        public bool TryGetProperty(string key, out Property property)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            return Property.TryGetProperty(key, this.properties, out property);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/SonarQube.Common.UnitTests/SonarQube.Common.UnitTests.csproj
+++ b/Tests/SonarQube.Common.UnitTests/SonarQube.Common.UnitTests.csproj
@@ -53,10 +53,14 @@
     <Compile Include="..\..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
+    <Compile Include="AggregatePropertiesProviderTests.cs" />
+    <Compile Include="CmdLineArgsPropertiesProviderTests.cs" />
     <Compile Include="ConsoleLoggerTests.cs" />
     <Compile Include="FileLocatorTests.cs" />
     <Compile Include="FilePropertiesProviderTests.cs" />
     <Compile Include="AnalysisConfigTests.cs" />
+    <Compile Include="AnalysisPropertyFileProviderTests.cs" />
+    <Compile Include="Infrastructure\ListSettingsProvider.cs" />
     <Compile Include="Infrastructure\OutputCaptureScope.cs" />
     <Compile Include="ProcessRunnerTests.cs" />
     <Compile Include="ProjectInfoTests.cs" />


### PR DESCRIPTION
Added processors to handle obtaining properties from the command line properties and files
Added a property aggregator to handle resolving properties from multiple providers
Added unit tests

To simplify the review process I'm trying to break the argument parsing changes into chunks, of which this is the first. The changes in this commit are mainly additive: they don't change the existing code use the new providers.
The next step will be to start refactoring the existing code to use the new properties providers instead of from the sonar-runner.properties file.