### PR TITLE
SONARMSBRU-79: pass the default settings file location to the pre-processor

### DIFF
--- a/SonarQube.Bootstrapper/BootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/BootstrapperSettings.cs
@@ -66,6 +66,7 @@ namespace SonarQube.Bootstrapper
         private readonly ILogger logger;
         private readonly string sonarQubeUrl;
         private readonly AnalysisPhase analysisPhase;
+        private readonly string childCmdLineArgs;
 
         private string tempDir;
         private string preProcFilePath;
@@ -73,7 +74,7 @@ namespace SonarQube.Bootstrapper
         
         #region Constructor(s)
         
-        public BootstrapperSettings(string sonarQubeUrl, AnalysisPhase phase, ILogger logger)
+        public BootstrapperSettings(AnalysisPhase phase, string childCmdLineArgs, string sonarQubeUrl, ILogger logger)
         {
             if (sonarQubeUrl == null)
             {
@@ -86,6 +87,7 @@ namespace SonarQube.Bootstrapper
 
             this.sonarQubeUrl = sonarQubeUrl;
             this.analysisPhase = phase;
+            this.childCmdLineArgs = childCmdLineArgs;
             this.logger = logger;
         }
 
@@ -141,26 +143,22 @@ namespace SonarQube.Bootstrapper
 
         public string SupportedBootstrapperVersionsFilePath
         {
-            get
-            {
-                return this.EnsurePathIsAbsolute(SupportedVersionsFilename);
-            }
+            get { return this.EnsurePathIsAbsolute(SupportedVersionsFilename); }
         }
 
         public Version BootstrapperVersion
         {
-            get
-            {
-                return new Version(LogicalVersionString);
-            }
+            get { return new Version(LogicalVersionString); }
         }
 
         public AnalysisPhase Phase
         {
-            get
-            {
-                return this.analysisPhase;
-            }
+            get { return this.analysisPhase; }
+        }
+
+        public string ChildCmdLineArgs
+        {
+            get { return this.childCmdLineArgs; }
         }
 
         #endregion

--- a/SonarQube.Bootstrapper/Interfaces/IBootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/Interfaces/IBootstrapperSettings.cs
@@ -54,5 +54,10 @@ namespace SonarQube.Bootstrapper
         Version BootstrapperVersion { get; }
 
         AnalysisPhase Phase { get; }
+
+        /// <summary>
+        /// The command line arguments to pass to the child process
+        /// </summary>
+        string ChildCmdLineArgs { get; }
     }
 }

--- a/SonarQube.Bootstrapper/Resources.Designer.cs
+++ b/SonarQube.Bootstrapper/Resources.Designer.cs
@@ -97,15 +97,6 @@ namespace SonarQube.Bootstrapper {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find the sonar-project.properties from the sonar-runner in %PATH%..
-        /// </summary>
-        internal static string ERROR_CouldNotFindSonarRunnerProperties {
-            get {
-                return ResourceManager.GetString("ERROR_CouldNotFindSonarRunnerProperties", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Failed to update the SonarQube MSBuild Runner binaries. Verify that the C# plugin is correctly installed on the SonarQube server and that the SonarQube server has been restarted..
         /// </summary>
         internal static string ERROR_FailedToUpdateRunnerBinaries {
@@ -151,7 +142,7 @@ namespace SonarQube.Bootstrapper {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} ({1} argument(s) passed).
+        ///   Looks up a localized string similar to {0} started..
         /// </summary>
         internal static string INFO_ProcessingStarted {
             get {

--- a/SonarQube.Bootstrapper/Resources.resx
+++ b/SonarQube.Bootstrapper/Resources.resx
@@ -129,9 +129,6 @@
   <data name="ERROR_CmdLine_UrlRequired" xml:space="preserve">
     <value>The SonarQube URL must be specified in a settings file or on the command line (e.g. using /d:sonar.host.url=http://myserver:9000 )</value>
   </data>
-  <data name="ERROR_CouldNotFindSonarRunnerProperties" xml:space="preserve">
-    <value>Could not find the sonar-project.properties from the sonar-runner in %PATH%.</value>
-  </data>
   <data name="ERROR_FailedToUpdateRunnerBinaries" xml:space="preserve">
     <value>Failed to update the SonarQube MSBuild Runner binaries. Verify that the C# plugin is correctly installed on the SonarQube server and that the SonarQube server has been restarted.</value>
   </data>
@@ -148,7 +145,7 @@
     <value>Downloading {0} from {1} to {2}</value>
   </data>
   <data name="INFO_ProcessingStarted" xml:space="preserve">
-    <value>{0} ({1} argument(s) passed)</value>
+    <value>{0} started.</value>
   </data>
   <data name="INFO_ProcessingSucceeded" xml:space="preserve">
     <value>{0} succeeded.</value>

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperExeTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperExeTests.cs
@@ -216,12 +216,16 @@ namespace SonarQube.Bootstrapper.Tests
 
         [TestMethod]
         public void Exe__Version0_9Compatibility()
-        { 
+        {
             // Tests compatibility with the bootstrapper API used in v0.9
             // The pre-processor should be called if any arguments are passed.
             // The post-processor should be called if no arguments are passed.
-            // However, there must be a default settings file next to the
-            // bootstrapper exe to supply the necessary settings.
+
+            // Default settings:
+            // There must be a default settings file next to the bootstrapper exe to supply 
+            // the necessary settings, and the bootstrapper should pass this settings path 
+            // to the pre-processor (since the pre-process is downloaded to a different
+            // directory).
 
             // Arrange
             string rootDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
@@ -254,7 +258,7 @@ namespace SonarQube.Bootstrapper.Tests
                     mockUpdater.AssertVersionChecked();
 
                     string logPath = DummyExeHelper.AssertDummyPreProcLogExists(binDir, this.TestContext);
-                    DummyExeHelper.AssertExpectedLogContents(logPath, "/v:version\r\n/n:name\r\n/k:key\r\n");
+                    DummyExeHelper.AssertExpectedLogContents(logPath, "/v:version\r\n/n:name\r\n/k:key\r\n/s:" + defaultPropertiesFilePath + "\r\n");
 
                     DummyExeHelper.AssertDummyPostProcLogDoesNotExist(binDir);
 
@@ -319,7 +323,7 @@ namespace SonarQube.Bootstrapper.Tests
             defaultProperties.Save(defaultPropertiesFilePath);
             return defaultPropertiesFilePath;
         }
-        
+
         #endregion
 
         #region Checks

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
@@ -26,9 +26,10 @@ namespace SonarQube.Bootstrapper.Tests
         {
             string validUrl = "http://myserver";
             ILogger validLogger = new TestLogger();
+            string validArgs = string.Empty;
 
-            AssertException.Expects<ArgumentNullException>(() => new BootstrapperSettings(null, AnalysisPhase.PostProcessing, validLogger));
-            AssertException.Expects<ArgumentNullException>(() => new BootstrapperSettings(validUrl, AnalysisPhase.PreProcessing, null));
+            AssertException.Expects<ArgumentNullException>(() => new BootstrapperSettings(AnalysisPhase.PostProcessing, validArgs, null, validLogger));
+            AssertException.Expects<ArgumentNullException>(() => new BootstrapperSettings(AnalysisPhase.PreProcessing, validArgs, validUrl, null));
         }
 
         [TestMethod]
@@ -44,7 +45,7 @@ namespace SonarQube.Bootstrapper.Tests
                 envScope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, @"c:\temp");
 
                 // 1. Default value -> relative to download dir
-                IBootstrapperSettings settings = new BootstrapperSettings("http://sq", AnalysisPhase.PreProcessing, logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", logger);
                 AssertExpectedServerUrl("http://sq", settings);
                 AssertExpectedPreProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, "SonarQube.MSBuild.PreProcessor.exe"), settings);
                 AssertExpectedPostProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, "SonarQube.MSBuild.PostProcessor.exe"), settings);
@@ -63,7 +64,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, "legacy tf build");
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
                 
-                IBootstrapperSettings settings = new BootstrapperSettings("http://sq", AnalysisPhase.PreProcessing, logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", logger);
                 AssertExpectedDownloadDir(Path.Combine("legacy tf build", DownloadFolderRelativePath), settings);
             }
 
@@ -73,7 +74,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, null);
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, "tfs build");
                 
-                IBootstrapperSettings settings = new BootstrapperSettings("http://sq", AnalysisPhase.PreProcessing, logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", logger);
                 AssertExpectedDownloadDir(Path.Combine("tfs build", DownloadFolderRelativePath), settings);
             }
 
@@ -83,7 +84,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, null);
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
 
-                IBootstrapperSettings settings = new BootstrapperSettings("http://sq", AnalysisPhase.PreProcessing, logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, "http://sq", string.Empty, logger);
                 AssertExpectedDownloadDir(Path.Combine(Directory.GetCurrentDirectory(), DownloadFolderRelativePath), settings);
             }
         }

--- a/Tests/SonarQube.Common.UnitTests/FilePropertyProviderTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/FilePropertyProviderTests.cs
@@ -74,6 +74,7 @@ namespace SonarQube.Common.UnitTests
             // Assert
             AssertExpectedPropertiesFile(validPropertiesFile, provider, logger);
             AssertPropertyExists("key1", "value1", provider);
+            AssertIsDefaultPropertiesFile(provider);
         }
 
         [TestMethod]
@@ -99,6 +100,7 @@ namespace SonarQube.Common.UnitTests
             // Assert
             AssertExpectedPropertiesFile(validPropertiesFile, provider, logger);
             AssertPropertyExists("xxx", "value with spaces", provider);
+            AssertIsNotDefaultPropertiesFile(provider);
         }
 
         [TestMethod]
@@ -219,10 +221,7 @@ namespace SonarQube.Common.UnitTests
 
         private static void AssertExpectedPropertiesFile(string expectedFilePath, IAnalysisPropertyProvider actualProvider, TestLogger logger)
         {
-            Assert.IsNotNull(actualProvider, "Supplied provider should not be null");
-            Assert.IsInstanceOfType(actualProvider, typeof(FilePropertyProvider), "Expecting a file provider");
-
-            FilePropertyProvider fileProvider = (FilePropertyProvider)actualProvider;
+            FilePropertyProvider fileProvider = AssertIsFilePropertyProvider(actualProvider);
 
             Assert.IsNotNull(fileProvider.PropertiesFile, "Properties file object should not be null");
             Assert.AreEqual(expectedFilePath, fileProvider.PropertiesFile.FilePath, "Properties were not loaded from the expected location");
@@ -234,6 +233,26 @@ namespace SonarQube.Common.UnitTests
             bool exists = actualProvider.TryGetProperty(key, out actualProperty);
             Assert.IsTrue(exists, "Specified property does not exist. Key: {0}", key);
             Assert.AreEqual(expectedValue, actualProperty.Value, "Property does not have the expected value. Key: {0}", key);
+        }
+
+        private static void AssertIsDefaultPropertiesFile(IAnalysisPropertyProvider actualProvider)
+        {
+            FilePropertyProvider fileProvider = AssertIsFilePropertyProvider(actualProvider);
+            Assert.IsTrue(fileProvider.IsDefaultSettingsFile, "Expecting the provider to be marked as using the default properties file");
+        }
+
+        private static void AssertIsNotDefaultPropertiesFile(IAnalysisPropertyProvider actualProvider)
+        {
+            FilePropertyProvider fileProvider = AssertIsFilePropertyProvider(actualProvider);
+            Assert.IsFalse(fileProvider.IsDefaultSettingsFile, "Not expecting the provider to be marked as using the default properties file");
+        }
+
+        private static FilePropertyProvider AssertIsFilePropertyProvider(IAnalysisPropertyProvider actualProvider)
+        {
+            Assert.IsNotNull(actualProvider, "Supplied provider should not be null");
+            Assert.IsInstanceOfType(actualProvider, typeof(FilePropertyProvider), "Expecting a file provider");
+
+            return (FilePropertyProvider)actualProvider;
         }
 
         #endregion

--- a/Tests/TestUtilities/SQPropertiesFileReader.cs
+++ b/Tests/TestUtilities/SQPropertiesFileReader.cs
@@ -61,12 +61,6 @@ namespace TestUtilities
             this.ExtractProperties(fullPath);
         }
 
-        // Should be dropped with SONARMSBRU-84
-        public IDictionary<string, string> GetProperties()
-        {
-            return properties;
-        }
-
         public string GetProperty(string propertyName)
         {
             string value;


### PR DESCRIPTION
If the bootstrapper is using its default settings file, it will need to explicitly pass the location of that file to the pre-processor using the /s: switch.

Added unit tests.