### PR TITLE
SONARMSBRU-93: Automatically copy the loader targets file

### DIFF
--- a/SonarQube.Bootstrapper/BuildAgentUpdater.cs
+++ b/SonarQube.Bootstrapper/BuildAgentUpdater.cs
@@ -7,14 +7,33 @@
 
 using SonarQube.Common;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
+using System.Reflection;
 
 namespace SonarQube.Bootstrapper
 {
     public class BuildAgentUpdater : IBuildAgentUpdater
     {
+        public /* for test purposes */ const string LoaderTargetsName = "SonarQube.Integration.ImportBefore.targets";
+
+        public /* for test purposes */ static IReadOnlyList<string> DestinationDirs
+        {
+            get
+            {
+                string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                return new string[]
+                    {
+                        Path.Combine(appData, "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                        Path.Combine(appData, "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                        Path.Combine(appData, "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore")
+                    };
+            }
+        }
+
         /// <summary>
         /// Gets a zip file containing the pre/post processors from the server
         /// </summary>
@@ -57,13 +76,12 @@ namespace SonarQube.Bootstrapper
                 ZipFile.ExtractToDirectory(downloadedZipFilePath, targetDir);
                 return true;
             }
-
         }
 
         /// <summary>
         /// Verifies that the pre/post-processors are compatible with this version of the bootstrapper
         /// </summary>
-        /// <remarks>Older C# plugins will not have the file contain the supported versions - 
+        /// <remarks>Older C# plugins will not have the file contain the supported versions -
         /// in this case we fail because we are not backwards compatible with those versions</remarks>
         /// <param name="versionFilePath">path to the XML file containing the supported versions</param>
         /// <param name="bootstrapperVersion">current version</param>
@@ -99,6 +117,81 @@ namespace SonarQube.Bootstrapper
             return false;
         }
 
+
+        public void InjectLoaderTargets(ILogger logger)
+        {
+            WarnOnGlobalTargetsFile(logger);
+            InternalCopyTargetsFile(logger);
+        }
+
+        private static void InternalCopyTargetsFile(ILogger logger)
+        {
+            string sourceTargetsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), LoaderTargetsName);
+            Debug.Assert(File.Exists(sourceTargetsPath), String.Format("Could not find the {0} file in the current director", LoaderTargetsName));
+
+            CopyIfDifferent(sourceTargetsPath, DestinationDirs, logger);
+        }
+
+        private static void CopyIfDifferent(string sourcePath, IEnumerable<string> destinationDirs, ILogger logger)
+        {
+            string sourceContent = GetReadOnlyFileContent(sourcePath);
+            string fileName = Path.GetFileName(sourcePath);
+
+            foreach (string destinationDir in destinationDirs)
+            {
+                string destinationPath = Path.Combine(destinationDir, fileName);
+
+                if (!File.Exists(destinationPath))
+                {
+                    Directory.CreateDirectory(destinationDir); // creates all the directories in the path if needed
+                    File.Copy(sourcePath, destinationPath, overwrite: false);
+                    logger.LogMessage(Resources.INFO_CopiedTargets, fileName, destinationDir);
+                }
+                else
+                {
+                    string destinationContent = GetReadOnlyFileContent(destinationPath);
+
+                    if (!String.Equals(sourceContent, destinationContent, StringComparison.Ordinal))
+                    {
+                        File.Copy(sourcePath, destinationPath, overwrite: true);
+                        logger.LogMessage(Resources.INFO_CopiedTargets, fileName, destinationDir);
+                    }
+                }
+            }
+        }
+
+        private static string GetReadOnlyFileContent(string path)
+        {
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                using (StreamReader sr = new StreamReader(fs))
+                {
+                    return sr.ReadToEnd();
+                }
+            }
+        }
+
+        private static void WarnOnGlobalTargetsFile(ILogger logger)
+        {
+            // Giving a warning is best effort - if the user has installed MSBUILD in a non-standard location then this will not work
+            string[] globalMsbuildTargetsDirs = new string[]
+            {
+                Path.Combine( Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "MSBuild", "14.0", "Microsoft.Common.Targets", "ImportBefore"),
+                Path.Combine( Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "MSBuild", "12.0", "Microsoft.Common.Targets", "ImportBefore"),
+                Path.Combine( Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "MSBuild", "4.0", "Microsoft.Common.Targets", "ImportBefore"),
+            };
+
+            foreach (string globalMsbuildTargetDir in globalMsbuildTargetsDirs)
+            {
+                string existingFile = Path.Combine(globalMsbuildTargetDir, LoaderTargetsName);
+
+                if (File.Exists(existingFile))
+                {
+                    logger.LogWarning(Resources.WARN_ExistingGlobalTargets, LoaderTargetsName, globalMsbuildTargetDir);
+                }
+            }
+        }
+
         private static string GetDownloadZipUrl(string url)
         {
             string downloadZipUrl = url;
@@ -111,6 +204,5 @@ namespace SonarQube.Bootstrapper
 
             return downloadZipUrl;
         }
-
     }
 }

--- a/SonarQube.Bootstrapper/Interfaces/IBuildAgentUpdater.cs
+++ b/SonarQube.Bootstrapper/Interfaces/IBuildAgentUpdater.cs
@@ -11,7 +11,8 @@ using System;
 namespace SonarQube.Bootstrapper
 {
     /// <summary>
-    /// Component that downloads the SonarQube.MSBuild.Runner binaries from the SonarQube server
+    /// Component that prepares the machine for the analysis. 
+    /// It copies targets files, downloads the SonarQube.MSBuild.Runner binaries from the SonarQube server, checks versions 
     /// </summary>
     /// <remarks>This interface was introduced to support testing</remarks>
     public interface IBuildAgentUpdater
@@ -28,5 +29,11 @@ namespace SonarQube.Bootstrapper
         /// Verifies that the pre/post-processors are compatible with this version of the bootstrapper
         /// </summary>
         bool CheckBootstrapperApiVersion(string versionFilePath, Version bootstrapperVersion);
+
+        /// <summary>
+        /// Copies the loader targets file - SonarQube.Integration.ImportBefore.targets - to a user specific location 
+        /// from where MsBuild can automatically import it. Also gives a warning if such a file is present in the non-user specific directory.
+        /// </summary>
+        void InjectLoaderTargets(ILogger logger);
     }
 }

--- a/SonarQube.Bootstrapper/Program.cs
+++ b/SonarQube.Bootstrapper/Program.cs
@@ -77,6 +77,8 @@ namespace SonarQube.Bootstrapper
                 return 1;
             }
 
+            updater.InjectLoaderTargets(logger);
+
             var preprocessorFilePath = settings.PreProcessorFilePath;
             var processRunner = new ProcessRunner();
             processRunner.Execute(preprocessorFilePath, settings.ChildCmdLineArgs, settings.TempDirectory, logger);

--- a/SonarQube.Bootstrapper/Resources.Designer.cs
+++ b/SonarQube.Bootstrapper/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace SonarQube.Bootstrapper {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copied {0} to {1}.
+        /// </summary>
+        internal static string INFO_CopiedTargets {
+            get {
+                return ResourceManager.GetString("INFO_CopiedTargets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Downloading {0} from {1} to {2}.
         /// </summary>
         internal static string INFO_Downloading {
@@ -201,6 +210,15 @@ namespace SonarQube.Bootstrapper {
         internal static string WARN_CmdLine_v09_Compat {
             get {
                 return ResourceManager.GetString("WARN_CmdLine_v09_Compat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This version of the bootstrapper automatically deploys {0}, however a copy has been found in {1}. Please remove it if it is not intentional..
+        /// </summary>
+        internal static string WARN_ExistingGlobalTargets {
+            get {
+                return ResourceManager.GetString("WARN_ExistingGlobalTargets", resourceCulture);
             }
         }
     }

--- a/SonarQube.Bootstrapper/Resources.resx
+++ b/SonarQube.Bootstrapper/Resources.resx
@@ -135,6 +135,9 @@
   <data name="ERROR_VersionMismatch" xml:space="preserve">
     <value>The C# plugin installed on the server is not compatible with the SonarQube.MSBuild.Runner.exe - either check the compatibility matrix or get the latest versions for both. </value>
   </data>
+  <data name="INFO_CopiedTargets" xml:space="preserve">
+    <value>Copied {0} to {1}</value>
+  </data>
   <data name="INFO_Downloading" xml:space="preserve">
     <value>Downloading {0} from {1} to {2}</value>
   </data>
@@ -164,5 +167,8 @@
   </data>
   <data name="WARN_CmdLine_v09_Compat" xml:space="preserve">
     <value>Please specify the command 'begin' or 'end' to indicate whether pre- or post-processing is required. These parameters will become mandatory in a later release.</value>
+  </data>
+  <data name="WARN_ExistingGlobalTargets" xml:space="preserve">
+    <value>This version of the bootstrapper automatically deploys {0}, however a copy has been found in {1}. Please remove it if it is not intentional.</value>
   </data>
 </root>

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperExeTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperExeTests.cs
@@ -61,6 +61,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateAttempted();
                 mockUpdater.AssertVersionNotChecked();
+                mockUpdater.AssertTargetsNotInjected();
 
                 logger.AssertWarningsLogged(0);
 
@@ -86,6 +87,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateAttempted();
                 mockUpdater.AssertVersionChecked();
+                mockUpdater.AssertTargetsNotInjected();
 
                 AssertDirectoryExists(binDir);
                 DummyExeHelper.AssertDummyPreProcLogDoesNotExist(binDir);
@@ -122,6 +124,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateAttempted();
                 mockUpdater.AssertVersionChecked();
+                mockUpdater.AssertTargetsInjected();
 
                 logger.AssertWarningsLogged(0);
 
@@ -156,6 +159,8 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateAttempted();
                 mockUpdater.AssertVersionChecked();
+                mockUpdater.AssertTargetsInjected();
+
                 logger.AssertWarningsLogged(0);
 
                 string logPath = DummyExeHelper.AssertDummyPreProcLogExists(binDir, this.TestContext);
@@ -189,6 +194,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateAttempted();
                 mockUpdater.AssertVersionChecked();
+                mockUpdater.AssertTargetsInjected();
 
                 logger.AssertWarningsLogged(1);
                 logger.AssertSingleWarningExists(BootstrapperSettings.DefaultHostUrl); // a warning about the default host url should have been logged
@@ -217,6 +223,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateNotAttempted();
                 mockUpdater.AssertVersionNotChecked();
+                mockUpdater.AssertTargetsNotInjected();
                 logger.AssertWarningsLogged(0);
 
                 string logPath = DummyExeHelper.AssertDummyPostProcLogExists(binDir, this.TestContext);
@@ -243,6 +250,7 @@ namespace SonarQube.Bootstrapper.Tests
                 // Assert
                 mockUpdater.AssertUpdateNotAttempted();
                 mockUpdater.AssertVersionNotChecked();
+                mockUpdater.AssertTargetsNotInjected();
                 logger.AssertWarningsLogged(0);
 
                 // The bootstrapper pass through any parameters it doesn't recognise so the post-processor
@@ -294,6 +302,7 @@ namespace SonarQube.Bootstrapper.Tests
 
                     mockUpdater.AssertUpdateAttempted();
                     mockUpdater.AssertVersionChecked();
+                    mockUpdater.AssertTargetsInjected();
 
                     string logPath = DummyExeHelper.AssertDummyPreProcLogExists(binDir, this.TestContext);
                     DummyExeHelper.AssertExpectedLogContents(logPath, "/v:version\r\n/n:name\r\n/k:key\r\n/s:" + defaultPropertiesFilePath + "\r\n");

--- a/Tests/SonarQube.Bootstrapper.Tests/Infrastructure/MockBuildAgentUpdater.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/Infrastructure/MockBuildAgentUpdater.cs
@@ -15,6 +15,7 @@ namespace SonarQube.Bootstrapper.Tests
     {
         private bool tryUpdateCalled;
         private bool checkVersionCalled;
+        private bool injectTargetsCalled;
 
         public class UpdatingEventArgs : EventArgs
         {
@@ -73,6 +74,17 @@ namespace SonarQube.Bootstrapper.Tests
             Assert.IsFalse(this.checkVersionCalled, "Not expecting IBuildUpdater.CheckBootstrapperVersion to be been called");
         }
 
+        public void AssertTargetsInjected()
+        {
+            Assert.IsTrue(this.injectTargetsCalled, "Expecting IBuildUpdater.InjectLoaderTargets to be been called");
+        }
+
+        public void AssertTargetsNotInjected()
+        {
+            Assert.IsFalse(this.injectTargetsCalled, "Not expecting IBuildUpdater.InjectLoaderTargets to be been called");
+        }
+
+
         #endregion
 
         #region IBuildAgentUpdater interface
@@ -110,6 +122,11 @@ namespace SonarQube.Bootstrapper.Tests
             }
 
             return this.TryUpdateReturnValue;
+        }
+
+        void IBuildAgentUpdater.InjectLoaderTargets(ILogger logger)
+        {
+            this.injectTargetsCalled = true;
         }
 
         #endregion


### PR DESCRIPTION
This is a partial implemention as it does not include the command line param that disables the copy. I am working on the second part now but since they are independent these changes can be reviewed. 