### PR TITLE
SONARMSBRU-101: verbs should match whole argument

### DIFF
--- a/SonarQube.Bootstrapper/ArgumentProcessor.cs
+++ b/SonarQube.Bootstrapper/ArgumentProcessor.cs
@@ -44,10 +44,10 @@ namespace SonarQube.Bootstrapper
             Descriptors = new List<ArgumentDescriptor>();
 
             Descriptors.Add(new ArgumentDescriptor(
-                id: BeginId, prefixes: new string[] { BeginVerb }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_Begin));
+                id: BeginId, prefixes: new string[] { BeginVerb }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_Begin, isVerb: true));
 
             Descriptors.Add(new ArgumentDescriptor(
-                id: EndId, prefixes: new string[] { EndVerb }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_End));
+                id: EndId, prefixes: new string[] { EndVerb }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_End, isVerb: true));
 
             Descriptors.Add(new ArgumentDescriptor(
                 id: InstallTargetsId, prefixes: new string[] { InstallTargetsPrefix }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_InstallTargets));

--- a/SonarQube.Common/CommandLine/ArgumentDescriptor.cs
+++ b/SonarQube.Common/CommandLine/ArgumentDescriptor.cs
@@ -27,8 +27,14 @@ namespace SonarQube.Common
         private readonly bool required;
         private readonly string description;
         private readonly bool allowMultiple;
+        private readonly bool isVerb;
 
         public ArgumentDescriptor(string id, string[] prefixes, bool required, string description, bool allowMultiple)
+            : this(id, prefixes, required, description, allowMultiple, false /* not a verb */)
+        {
+        }
+
+        public ArgumentDescriptor(string id, string[] prefixes, bool required, string description, bool allowMultiple, bool isVerb)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -48,6 +54,7 @@ namespace SonarQube.Common
             this.required = required;
             this.description = description;
             this.allowMultiple = allowMultiple;
+            this.isVerb = isVerb;
         }
 
         #region Properties
@@ -79,6 +86,12 @@ namespace SonarQube.Common
         /// false if it can be specified at most once
         /// </summary>
         public bool AllowMultiple { get { return this.allowMultiple; } }
+
+        /// <summary>
+        /// False if the argument has a value that follows the prefix,
+        /// true if the argument is just single word (e.g. "begin")
+        /// </summary>
+        public bool IsVerb { get { return this.isVerb; } }
 
         #endregion
     }

--- a/SonarQube.Common/CommandLine/CommandLineParser.cs
+++ b/SonarQube.Common/CommandLine/CommandLineParser.cs
@@ -18,8 +18,8 @@ namespace SonarQube.Common
     /// <remarks>The command line parsing makes a number of simplying assumptions:
     /// * order is unimportant
     /// * all arguments have a recognisable prefix e.g. /key= 
-    /// * prefixes are case-insensitive
-    /// * unrecognized arguments are treated as errors
+    /// * the first matching prefix will be used (so if descriptors have overlapping prefixes they need
+    ///   to be supplied to the parser in the correct order on construction)
     /// * the command line arguments are those supplied in Main(args) i.e. they have been converted
     ///   from a string to an array by the runtime. This means that quoted arguments will already have
     ///   been partially processed so a command line of:
@@ -152,7 +152,17 @@ namespace SonarQube.Common
             Debug.Assert(descriptor.Prefixes.Where(p => argument.StartsWith(p, ArgumentDescriptor.IdComparison)).Count() < 2,
                 "Not expecting the argument to match multiple prefixes");
 
-            string match = descriptor.Prefixes.FirstOrDefault(p => argument.StartsWith(p, ArgumentDescriptor.IdComparison));
+            string match = null;
+            if (descriptor.IsVerb)
+            {
+                // Verbs match the whole argument
+                match = descriptor.Prefixes.FirstOrDefault(p => ArgumentDescriptor.IdComparer.Equals(p, argument));
+            }
+            else
+            {
+                // Prefixes only match the start
+                match = descriptor.Prefixes.FirstOrDefault(p => argument.StartsWith(p, ArgumentDescriptor.IdComparison));
+            }
             return match;
         }
 

--- a/Tests/SonarQube.Bootstrapper.Tests/ArgumentProcessorTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/ArgumentProcessorTests.cs
@@ -100,15 +100,6 @@ namespace SonarQube.Bootstrapper.Tests
         }
 
         [TestMethod]
-        [Ignore] // SONARMSBRU-101
-        public void ArgProc_ArgumentsWithWellKnownVerb()
-        {
-            TestLogger logger = new TestLogger();
-
-            IBootstrapperSettings settings = CheckProcessingSucceeds(logger, "/d:sonar.host.url=foo", "begin", "begingX");
-        }
-
-        [TestMethod]
         public void ArgProc_UrlIsRequired()
         {
             // 0. Setup

--- a/Tests/SonarQube.Common.UnitTests/CommandLineParserTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/CommandLineParserTests.cs
@@ -138,6 +138,138 @@ namespace SonarQube.Common.UnitTests
             AssertExpectedInstancesCount(0, instances);
         }
 
+
+        [TestMethod]
+        [TestCategory("Verbs")]
+        public void Parser_Verbs_ExactMatchesOnly()
+        {
+            CommandLineParser parser;
+            IEnumerable<ArgumentInstance> instances;
+            TestLogger logger;
+
+            ArgumentDescriptor verb1 = new ArgumentDescriptor("v1", new string[] { "begin" }, false /* not required */, "desc1", false /* no multiples */, true);
+            parser = new CommandLineParser(new ArgumentDescriptor[] { verb1 }, true /* allow unrecognised */);
+
+            // 1. Exact match -> matched
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger, "begin");
+            AssertExpectedValue("v1", "", instances);
+            AssertExpectedInstancesCount(1, instances);
+
+            // 2. Partial match -> not matched
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger, "beginX");
+            AssertExpectedInstancesCount(0, instances);
+
+            // 3. Combination -> only exact matches matched
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger, "beginX", "begin", "beginY");
+            Assert.AreEqual(string.Empty, instances.First().Value, "Value for verb should be empty");
+            AssertExpectedInstancesCount(1, instances);
+            AssertExpectedValue("v1", "", instances);
+        }
+
+        [TestMethod]
+        [TestCategory("Verbs")]
+        public void Parser_Verbs_Multiples()
+        {
+            CommandLineParser parser;
+            IEnumerable<ArgumentInstance> instances;
+            TestLogger logger;
+
+            string[] args = new string[] { "verb" };
+
+            ArgumentDescriptor verb1 = new ArgumentDescriptor("v1", new string[] { "noMult" }, false /* required */, "noMult desc", false /* no multiples */, true);
+            ArgumentDescriptor verb2 = new ArgumentDescriptor("v2", new string[] { "multOk" }, false /* required */, "multOk desc", true /* allow multiples */, true);
+
+            parser = new CommandLineParser(new ArgumentDescriptor[] { verb1, verb2 }, true /* allow unrecognised */ );
+
+            // 1. Allowed multiples
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger, "multOk", "multOk");
+            AssertExpectedInstancesCount(2, instances);
+
+            // 2. Disallowed multiples
+            logger = CheckProcessingFails(parser, new string[] { "noMult", "noMult" });
+            logger.AssertSingleErrorExists("noMult");
+            logger.AssertErrorsLogged(1);
+        }
+
+        [TestMethod]
+        [TestCategory("Verbs")]
+        public void Parser_Verbs_Required()
+        {
+            CommandLineParser parser;
+            IEnumerable<ArgumentInstance> instances;
+            TestLogger logger;
+
+            string[] emptyArgs = new string[] { };
+            string[] matchingPrefixArgs = new string[] { "AAAa" };
+
+            // 1a. Argument is required but is missing -> error
+            ArgumentDescriptor d1 = new ArgumentDescriptor("id", new string[] { "AAA" }, true /* required */, "desc1", false /* no multiples */, true);
+            parser = new CommandLineParser(new ArgumentDescriptor[] { d1 }, false);
+            logger = CheckProcessingFails(parser, emptyArgs);
+
+            logger.AssertSingleErrorExists("desc1");
+            logger.AssertErrorsLogged(1);
+
+            // 1b. Argument is required but is only partial match -> missing -> error2
+            logger = CheckProcessingFails(parser, matchingPrefixArgs);
+
+            logger.AssertSingleErrorExists("desc1"); // missing arg
+            logger.AssertSingleErrorExists("AAAa"); // unrecognized since not exact match
+            logger.AssertErrorsLogged(2);
+
+
+            // 2a. Argument is not required, missing -> ok
+            d1 = new ArgumentDescriptor("id", new string[] { "AAA" }, false /* not required */, "desc1", false /* no multiples */, true);
+            parser = new CommandLineParser(new ArgumentDescriptor[] { d1 }, true);
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger, emptyArgs);
+
+            AssertExpectedInstancesCount(0, instances);
+
+            // 2b. Argument is not required, partial -> missing -> ok
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger, matchingPrefixArgs);
+
+            AssertExpectedInstancesCount(0, instances);
+        }
+
+        [TestMethod]
+        [TestCategory("Verbs")]
+        public void Parser_OverlappingVerbsAndPrefixes()
+        {
+            // Tests handling of verbs and non-verbs that start with the same values
+            CommandLineParser parser;
+            IEnumerable<ArgumentInstance> instances;
+            TestLogger logger;
+
+            ArgumentDescriptor verb1 = new ArgumentDescriptor("v1", new string[] { "X" }, false /* not required */, "verb1 desc", false /* no multiples */, true);
+            ArgumentDescriptor prefix1 = new ArgumentDescriptor("p1", new string[] { "XX" }, false /* not required */, "prefix1 desc", false /* no multiples */, false);
+            ArgumentDescriptor verb2 = new ArgumentDescriptor("v2", new string[] { "XXX" }, false /* not required */, "verb2 desc", false /* no multiples */, true);
+            ArgumentDescriptor prefix2 = new ArgumentDescriptor("p2", new string[] { "XXXX" }, false /* not required */, "prefix2 desc", false /* no multiples */, false);
+            
+            // NOTE: this test only works because the descriptors are supplied to parser ordered
+            // by decreasing prefix length
+            parser = new CommandLineParser(new ArgumentDescriptor[] { prefix2, verb2, prefix1, verb1 }, true /* allow unrecognised */);
+
+            // 1. Exact match -> matched
+            logger = new TestLogger();
+            instances = CheckProcessingSucceeds(parser, logger,
+                "X", // verb 1 - exact match
+                "XXAAA", // prefix 1 - has value A,
+                "XXX", // verb 2 - exact match,
+                "XXXXB" // prefix 2 - has value B,
+                );
+
+            AssertExpectedValue("v1", "", instances);
+            AssertExpectedValue("p1", "AAA", instances);
+            AssertExpectedValue("v2", "", instances);
+            AssertExpectedValue("p2", "B", instances);
+        }
+
         #endregion
 
         #region Checks


### PR DESCRIPTION
e.g."beginX" should not be recognised a the verb "begin"
Added unit tests