### PR TITLE
SONARMSBRU-99: Rename the bootstrapper to MSBuild.SonarQube.Runner.exe

### DIFF
--- a/PackagingProjects/BuildAgentPayload/BuildAgentPayload.csproj
+++ b/PackagingProjects/BuildAgentPayload/BuildAgentPayload.csproj
@@ -39,13 +39,13 @@
   </PropertyGroup>
   <ItemGroup>
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\SonarQube.Common.dll" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\SonarQube.MSBuild.Runner.exe" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\MSBuild.SonarQube.Runner.exe" />
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\SonarQube.Analysis.xml" />
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\bin\$(Configuration)\Targets\SonarQube.Integration.ImportBefore.targets" />
   </ItemGroup>
   <ItemGroup Condition="$(Configuration)== 'Debug'">
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\SonarQube.Common.pdb" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\SonarQube.MSBuild.Runner.pdb" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.Bootstrapper\bin\$(Configuration)\MSBuild.SonarQube.Runner.pdb" />
   </ItemGroup>
   <!-- Reference to dependencies to ensure the build order is correct -->
   <ItemGroup>

--- a/SonarQube.Bootstrapper/Interfaces/IBuildAgentUpdater.cs
+++ b/SonarQube.Bootstrapper/Interfaces/IBuildAgentUpdater.cs
@@ -12,13 +12,13 @@ namespace SonarQube.Bootstrapper
 {
     /// <summary>
     /// Component that prepares the machine for the analysis. 
-    /// It copies targets files, downloads the SonarQube.MSBuild.Runner binaries from the SonarQube server, checks versions 
+    /// It copies targets files, downloads the MSBuild.SonarQube.Runner binaries from the SonarQube server, checks versions 
     /// </summary>
     /// <remarks>This interface was introduced to support testing</remarks>
     public interface IBuildAgentUpdater
     {
         /// <summary>
-        /// Attempts to update the SonarQube.MSBuild.Runner binaries on the local machine
+        /// Attempts to update the MSBuild.SonarQube.Runner binaries on the local machine
         /// </summary>
         /// <param name="hostUrl">Address of the SonarQube server</param>
         /// <param name="targetDir">Directory to which the new binaries to copied</param>

--- a/SonarQube.Bootstrapper/Properties/AssemblyInfo.cs
+++ b/SonarQube.Bootstrapper/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("SonarQube.MSBuild.Runner")]
-[assembly: AssemblyProduct("SonarQube.MSBuild.Runner")]
+[assembly: AssemblyTitle("MSBuild.SonarQube.Runner")]
+[assembly: AssemblyProduct("MSBuild.SonarQube.Runner")]
 [assembly: AssemblyDescription("")]

--- a/SonarQube.Bootstrapper/Resources.Designer.cs
+++ b/SonarQube.Bootstrapper/Resources.Designer.cs
@@ -133,7 +133,7 @@ namespace SonarQube.Bootstrapper {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The C# plugin installed on the server is not compatible with the SonarQube.MSBuild.Runner.exe - either check the compatibility matrix or get the latest versions for both. .
+        ///   Looks up a localized string similar to The C# plugin installed on the server is not compatible with the MSBuild.SonarQube.Runner.exe - either check the compatibility matrix or get the latest versions for both. .
         /// </summary>
         public static string ERROR_VersionMismatch {
             get {

--- a/SonarQube.Bootstrapper/Resources.resx
+++ b/SonarQube.Bootstrapper/Resources.resx
@@ -142,7 +142,7 @@
     <value>{0} failed. Exit code: {1}</value>
   </data>
   <data name="ERROR_VersionMismatch" xml:space="preserve">
-    <value>The C# plugin installed on the server is not compatible with the SonarQube.MSBuild.Runner.exe - either check the compatibility matrix or get the latest versions for both. </value>
+    <value>The C# plugin installed on the server is not compatible with the MSBuild.SonarQube.Runner.exe - either check the compatibility matrix or get the latest versions for both. </value>
   </data>
   <data name="INFO_Downloading" xml:space="preserve">
     <value>Downloading {0} from {1} to {2}</value>

--- a/SonarQube.Bootstrapper/SonarQube.Analysis.xml
+++ b/SonarQube.Bootstrapper/SonarQube.Analysis.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-  This file defines properties which would be understood by the SonarQube.MsBuild.Runner, if not overridden (see below)
-  By default the SonarQube.MsBuild.Runner.exe picks-up a file named SonarQube.Analysis.xml in the folder it
+  This file defines properties which would be understood by the MSBuild.SonarQube.Runner, if not overridden (see below)
+  By default the MSBuild.SonarQube.Runner.exe picks-up a file named SonarQube.Analysis.xml in the folder it
   is located (if it exists). It is possible to use another properties file by using the /s:filePath.xml flag
   
   The overriding strategy of property values is the following:

--- a/SonarQube.Bootstrapper/SonarQube.Bootstrapper.csproj
+++ b/SonarQube.Bootstrapper/SonarQube.Bootstrapper.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Bootstrapper</RootNamespace>
-    <AssemblyName>SonarQube.MSBuild.Runner</AssemblyName>
+    <AssemblyName>MSBuild.SonarQube.Runner</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/SonarQube.TeamBuild.PreProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Resources.Designer.cs
@@ -146,7 +146,7 @@ namespace SonarQube.TeamBuild.PreProcessor {
         ///- SonarQube project key
         ///- SonarQube project name
         ///- SonarQube project version
-        ///The full path to a settings file can also be supplied. If it is not supplied, the exe will attempt to locate a default settings file in the same directory as the SonarQube.MSBuild.Runner..
+        ///The full path to a settings file can also be supplied. If it is not supplied, the exe will attempt to locate a default settings file in the same directory as the MSBuild.SonarQube.Runner..
         /// </summary>
         public static string ERROR_InvalidCommandLineArgs {
             get {

--- a/SonarQube.TeamBuild.PreProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PreProcessor/Resources.resx
@@ -149,7 +149,7 @@
 - SonarQube project key
 - SonarQube project name
 - SonarQube project version
-The full path to a settings file can also be supplied. If it is not supplied, the exe will attempt to locate a default settings file in the same directory as the SonarQube.MSBuild.Runner.</value>
+The full path to a settings file can also be supplied. If it is not supplied, the exe will attempt to locate a default settings file in the same directory as the MSBuild.SonarQube.Runner.</value>
   </data>
   <data name="ERROR_InvokedFromBootstrapper0_9" xml:space="preserve">
     <value>You are using MSBuild SonarQube Runner 0.9 which is not compatible with the current C# plugin. Please upgrade the MSBuild SonarQube Runner located on the build agent.</value>

--- a/VsoBuildStepSources/SonarQubePreBuild/SonarQubePreBuild.ps1
+++ b/VsoBuildStepSources/SonarQubePreBuild/SonarQubePreBuild.ps1
@@ -27,7 +27,7 @@ Write-Verbose -Verbose "serverUrl = $($serviceEndpoint.Url)"
 Write-Verbose -Verbose "serverUsername = $($serviceEndpoint.Authorization.Parameters.UserName)"
 
 #
-# These variables need to be updated when deploying different versions of sonar-runner / sonarqube.msbuild.runner
+# These variables need to be updated when deploying different versions of sonar-runner / MSBuild.SonarQube.Runner
 #
 $currentDir = (Get-Item -Path ".\" -Verbose).FullName
 $sonarRunnerDir = [System.IO.Path]::Combine($currentDir, "sonar-runner-dist-2.4", "sonar-runner-2.4", "bin")


### PR DESCRIPTION
Note: this only changes the name of bootstrapper. None of the other files are affected (i.e. the pre-processor, post-processor, tasks assembly etc).