### PR TITLE
SONARMSBRU-99: remaining file renamings

### DIFF
--- a/PackagingProjects/CSharpPluginPayload/CSharpPluginPayload.csproj
+++ b/PackagingProjects/CSharpPluginPayload/CSharpPluginPayload.csproj
@@ -40,18 +40,15 @@
     <AssemblyName>CSharpPluginPayload</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\SonarQube.MSBuild.PreProcessor.exe" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\MSBuild.SonarQube.Internal.PreProcess.exe" />
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\SupportedBootstrapperVersions.xml" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\SonarQube.MSBuild.PreProcessor.exe.config" />
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\Newtonsoft.Json.dll" />
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\SonarQube.Common.dll" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PostProcessor\bin\$(Configuration)\SonarQube.MSBuild.PostProcessor.exe" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PostProcessor\bin\$(Configuration)\SonarQube.MSBuild.PostProcessor.exe.config" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PostProcessor\bin\$(Configuration)\MSBuild.SonarQube.Internal.PostProcess.exe" />
     <FilesToCopy Include="$(SourcesRoot)\SonarRunner.Shim\bin\$(Configuration)\SonarRunner.Shim.exe" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarRunner.Shim\bin\$(Configuration)\SonarRunner.Shim.exe.config" />
     <FilesToCopy Include="$(SourcesRoot)\SonarRunner.Shim\sonar-runner.zip" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.Integration\bin\$(Configuration)\SonarQube.TeamBuild.Integration.dll" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\bin\$(Configuration)\SonarQube.MSBuild.Tasks.dll" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.Integration\bin\$(Configuration)\TeamBuild.SonarQube.Integration.dll" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\bin\$(Configuration)\SonarQube.Integration.Tasks.dll" />
     <TargetsToCopy Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\bin\$(Configuration)\Targets\SonarQube.Integration.targets" />
     <!-- Reference to dependencies to ensure the build order is correct -->
     <ProjectReference Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\SonarQube.MSBuild.Tasks.csproj">
@@ -76,12 +73,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(Configuration)== 'Debug'">
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\SonarQube.MSBuild.PreProcessor.pdb" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\MSBuild.SonarQube.Internal.PreProcess.pdb" />
     <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PreProcessor\bin\$(Configuration)\SonarQube.Common.pdb" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PostProcessor\bin\$(Configuration)\SonarQube.MSBuild.PostProcessor.pdb" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.PostProcessor\bin\$(Configuration)\MSBuild.SonarQube.Internal.PostProcess.pdb" />
     <FilesToCopy Include="$(SourcesRoot)\SonarRunner.Shim\bin\$(Configuration)\SonarRunner.Shim.pdb" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.Integration\bin\$(Configuration)\SonarQube.TeamBuild.Integration.pdb" />
-    <FilesToCopy Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\bin\$(Configuration)\SonarQube.MSBuild.Tasks.pdb" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.TeamBuild.Integration\bin\$(Configuration)\TeamBuild.SonarQube.Integration.pdb" />
+    <FilesToCopy Include="$(SourcesRoot)\SonarQube.MSBuild.Tasks\bin\$(Configuration)\SonarQube.Integration.Tasks.pdb" />
   </ItemGroup>
   <ItemGroup>
     <None Include="RepackageCSharpPlugin.ps1" />

--- a/SonarQube.Bootstrapper/BootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/BootstrapperSettings.cs
@@ -36,8 +36,8 @@ namespace SonarQube.Bootstrapper
         public const string IntegrationUrlSuffix = "/static/csharp/" + SonarQubeIntegrationFilename;
 
         // Exes to launched by the bootstrapper
-        public const string PreProcessorExeName = "SonarQube.MSBuild.PreProcessor.exe";
-        public const string PostProcessorExeName = "SonarQube.MSBuild.PostProcessor.exe";
+        public const string PreProcessorExeName = "MSBuild.SonarQube.Internal.PreProcess.exe";
+        public const string PostProcessorExeName = "MSBuild.SonarQube.Internal.PostProcess.exe";
 
         #region Working directory
         // Variables used when calculating the working directory

--- a/SonarQube.MSBuild.Tasks/Properties/AssemblyInfo.cs
+++ b/SonarQube.MSBuild.Tasks/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("SonarQube.MSBuild.Tasks")]
-[assembly: AssemblyProduct("SonarQube.MSBuild.Tasks")]
+[assembly: AssemblyTitle("SonarQube.Integration.Tasks")]
+[assembly: AssemblyProduct("SonarQube.Integration.Tasks")]
 [assembly: AssemblyDescription("")]

--- a/SonarQube.MSBuild.Tasks/SonarQube.MSBuild.Tasks.csproj
+++ b/SonarQube.MSBuild.Tasks/SonarQube.MSBuild.Tasks.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.MSBuild.Tasks</RootNamespace>
-    <AssemblyName>SonarQube.MSBuild.Tasks</AssemblyName>
+    <AssemblyName>SonarQube.Integration.Tasks</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -105,7 +105,7 @@
   <PropertyGroup Condition=" $(SonarQubeTempPath) != '' AND $(SonarQubeBuildTasksAssemblyFile) == '' ">
     <!-- Assume that the tasks assembly is in the same location as this targets file 
          or in a parent directory unless another location has already been specified. -->
-    <SonarQubeBuildTasksAssemblyFile>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SonarQube.MSBuild.Tasks.dll))\SonarQube.MSBuild.Tasks.dll</SonarQubeBuildTasksAssemblyFile>
+    <SonarQubeBuildTasksAssemblyFile>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), SonarQube.Integration.Tasks.dll))\SonarQube.Integration.Tasks.dll</SonarQubeBuildTasksAssemblyFile>
   </PropertyGroup>
 
   <!-- Unescape the paths to work around the issue "MSBuild 4.0 UsingTask cannot have a path with parentheses".

--- a/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
+++ b/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.TeamBuild.Integration</RootNamespace>
-    <AssemblyName>SonarQube.TeamBuild.Integration</AssemblyName>
+    <AssemblyName>TeamBuild.SonarQube.Integration</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/SonarQube.TeamBuild.PostProcessor/SonarQube.TeamBuild.PostProcessor.csproj
+++ b/SonarQube.TeamBuild.PostProcessor/SonarQube.TeamBuild.PostProcessor.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.TeamBuild.PostProcessor</RootNamespace>
-    <AssemblyName>SonarQube.MSBuild.PostProcessor</AssemblyName>
+    <AssemblyName>MSBuild.SonarQube.Internal.PostProcess</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/SonarQube.TeamBuild.PreProcessor/Properties/AssemblyInfo.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("SonarQube.MSBuild.PreProcessor")]
-[assembly: AssemblyProduct("SonarQube.MSBuild.PreProcessor")]
+[assembly: AssemblyTitle("MSBuild.SonarQube.Internal.PreProcess")]
+[assembly: AssemblyProduct("MSBuild.SonarQube.Internal.PreProcess")]
 [assembly: AssemblyDescription("")]

--- a/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
+++ b/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.TeamBuild.PreProcessor</RootNamespace>
-    <AssemblyName>SonarQube.MSBuild.PreProcessor</AssemblyName>
+    <AssemblyName>MSBuild.SonarQube.Internal.PreProcess</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
@@ -47,8 +47,8 @@ namespace SonarQube.Bootstrapper.Tests
                 // 1. Default value -> relative to download dir
                 IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", true, logger);
                 AssertExpectedServerUrl("http://sq", settings);
-                AssertExpectedPreProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, "SonarQube.MSBuild.PreProcessor.exe"), settings);
-                AssertExpectedPostProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, "SonarQube.MSBuild.PostProcessor.exe"), settings);
+                AssertExpectedPreProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, BootstrapperSettings.PreProcessorExeName), settings);
+                AssertExpectedPostProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, BootstrapperSettings.PostProcessorExeName), settings);
             }
         }
 

--- a/Tests/SonarQube.Bootstrapper.Tests/SonarQube.Bootstrapper.Tests.csproj
+++ b/Tests/SonarQube.Bootstrapper.Tests/SonarQube.Bootstrapper.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Bootstrapper.Tests</RootNamespace>
-    <AssemblyName>SonarQube.Bootstrapper.Tests</AssemblyName>
+    <AssemblyName>SonarQube.MSBuild.Runner.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("SonarQube.MSBuild.Tasks.IntegrationTests")]
-[assembly: AssemblyProduct("SonarQube.MSBuild.Tasks.IntegrationTests")]
+[assembly: AssemblyTitle("SonarQube.Integration.Tasks.IntegrationTests")]
+[assembly: AssemblyProduct("SonarQube.Integration.Tasks.IntegrationTests")]
 [assembly: AssemblyDescription("")]

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/SonarQube.MSBuild.Tasks.IntegrationTests.csproj
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/SonarQube.MSBuild.Tasks.IntegrationTests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.MSBuild.Tasks.IntegrationTests</RootNamespace>
-    <AssemblyName>SonarQube.MSBuild.Tasks.IntegrationTests</AssemblyName>
+    <AssemblyName>SonarQube.Integration.Tasks.IntegrationTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/Properties/AssemblyInfo.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("SonarQube.MSBuild.Tasks.UnitTests")]
-[assembly: AssemblyProduct("SonarQube.MSBuild.Tasks.UnitTests")]
+[assembly: AssemblyTitle("SonarQube.Integration.Tasks.UnitTests")]
+[assembly: AssemblyProduct("SonarQube.Integration.Tasks.UnitTests")]
 [assembly: AssemblyDescription("")]

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/SonarQube.MSBuild.Tasks.UnitTests.csproj
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/SonarQube.MSBuild.Tasks.UnitTests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.MSBuild.Tasks.UnitTests</RootNamespace>
-    <AssemblyName>SonarQube.MSBuild.Tasks.UnitTests</AssemblyName>
+    <AssemblyName>SonarQube.Integration.Tasks.UnitTests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/SonarQube.TeamBuild.Integration.Tests.csproj
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/SonarQube.TeamBuild.Integration.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.TeamBuild.Integration.Tests</RootNamespace>
-    <AssemblyName>SonarQube.TeamBuild.Integration.Tests</AssemblyName>
+    <AssemblyName>TeamBuild.SonarQube.Integration.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/SonarQube.TeamBuild.PostProcessor.Tests.csproj
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/SonarQube.TeamBuild.PostProcessor.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.TeamBuild.PostProcessor.Tests</RootNamespace>
-    <AssemblyName>SonarQube.TeamBuild.PostProcessor.Tests</AssemblyName>
+    <AssemblyName>MSBuild.SonarQube.Internal.PostProcess.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/SonarQube.TeamBuild.PreProcessor.Tests.csproj
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/SonarQube.TeamBuild.PreProcessor.Tests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.TeamBuild.PreProcessor.Tests</RootNamespace>
-    <AssemblyName>SonarQube.TeamBuild.PreProcessor.Tests</AssemblyName>
+    <AssemblyName>MSBuild.SonarQube.Internal.PreProcess.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Tests/TestUtilities/DummyExeHelper.cs
+++ b/Tests/TestUtilities/DummyExeHelper.cs
@@ -20,8 +20,8 @@ namespace TestUtilities
     public static class DummyExeHelper
     {
         // FIX: should be using constants in the product code
-        public const string PreProcessorExeName = "SonarQube.MSBuild.PreProcessor.exe";
-        public const string PostProcessorExeName = "SonarQube.MSBuild.PostProcessor.exe";
+        public const string PreProcessorExeName = "MSBuild.SonarQube.Internal.PreProcess.exe";
+        public const string PostProcessorExeName = "MSBuild.SonarQube.Internal.PostProcess.exe";
 
         #region Public methods
 

--- a/VsoBuildStepSources/SonarQubePreBuild/SonarQubePreBuild.ps1
+++ b/VsoBuildStepSources/SonarQubePreBuild/SonarQubePreBuild.ps1
@@ -32,8 +32,8 @@ Write-Verbose -Verbose "serverUsername = $($serviceEndpoint.Authorization.Parame
 $currentDir = (Get-Item -Path ".\" -Verbose).FullName
 $sonarRunnerDir = [System.IO.Path]::Combine($currentDir, "sonar-runner-dist-2.4", "sonar-runner-2.4", "bin")
 $sonarRunnerPath = [System.IO.Path]::Combine($sonarRunnerDir, "sonar-runner.bat")
-$sonarMsBuildRunnerDir = [System.IO.Path]::Combine($currentDir, "SonarQube.MSBuild.Runner-0.9")
-$sonarMsBuildRunnerPath = [System.IO.Path]::Combine($sonarMsBuildRunnerDir, "SonarQube.MSBuild.Runner.exe")
+$sonarMsBuildRunnerDir = [System.IO.Path]::Combine($currentDir, "MSBuild.SonarQube.Runner-1.0")
+$sonarMsBuildRunnerPath = [System.IO.Path]::Combine($sonarMsBuildRunnerDir, "MSBuild.SonarQube.Runner.exe")
 
 $targetsFileInitialPath = [System.IO.Path]::Combine($sonarMsBuildRunnerDir, "SonarQube.Integration.ImportBefore.targets")
 $propertiesFileDir = [System.IO.Path]::Combine($sonarRunnerDir, "..\", "conf")


### PR DESCRIPTION
Changed:
SonarQube.MSBuild.PreProcessor.exe -> MSBuild.SonarQube.Internal.PreProcess.exe
SonarQube.MSBuild.PostProcessor.exe -> MSBuild.SonarQube.Internal.PostProcess.exe
SonarQube.TeamBuild.Integration.dll -> TeamBuild.SonarQube.Integration.dll
SonarQube.MSBuild.Tasks.dll -> SonarQube.Integration.Tasks.dll

Unchanged: SonarQube.Common.dll, SonarQube.Integration.targets, SonarQube.Integration.ImportBefore.targets

Done in a previous commit: SonarQube.MSBuild.Runner.exe -> MSBuild.SonarQube.Runner.exe