### PR TITLE
SONARMSBRU-79: added placeholders to default config file for server credentials

### DIFF
--- a/SonarQube.Bootstrapper/SonarQube.Analysis.xml
+++ b/SonarQube.Bootstrapper/SonarQube.Analysis.xml
@@ -19,8 +19,11 @@
 <SonarQubeAnalysisProperties  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
 
   <Property Name="sonar.host.url">http://localhost:9000</Property>
-
+  
   <!--
+  <Property Name="sonar.login"></Property>
+  <Property Name="sonar.password"></Property>
+  
   <Property Name="sonar.jdbc.url">jdbc:jtds:sqlserver://mySqlServer/sonar;instance=SQLEXPRESS;SelectMethod=Cursor</Property>
   <Property Name="sonar.jdbc.username">sonar</Property>
   <Property Name="sonar.jdbc.password">sonar</Property>

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
@@ -63,7 +63,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
 
             using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri"))
             {
-                TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(new ConsoleLogger());
+                TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(new TestLogger());
                 Assert.IsNotNull(settings, "Test setup error: TFS environment variables have not been set correctly");
                 expectedConfigFilePath = settings.AnalysisConfigFilePath;
 
@@ -128,7 +128,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             string configFilePath;
             using (PreprocessTestUtils.CreateValidLegacyTeamBuildScope("tfs uri", "build uri"))
             {
-                TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(new ConsoleLogger());
+                TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(new TestLogger());
                 Assert.IsNotNull(settings, "Test setup error: TFS environment variables have not been set correctly");
                 configFilePath = settings.AnalysisConfigFilePath;
 


### PR DESCRIPTION
Simplifies the user experience for users who have authentication enabled.

I don't think we want to provide suggested values in the placeholders. By default, authentication is turned off so only users who have enabled authentication will need them, and it's up to them which account they want to use.