### PR TITLE
[SONARSMSBRU-107] Fix detection of MSTest projects

### DIFF
--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -57,7 +57,7 @@
         single character wildcard and "*" is the multi-character wildcard (zero to many).
 
     2) MSTest projects will be treated as test projects.
-        The $(ProjectTypeGuid) of MS Test projects contains a specific guid
+        The $(ProjectTypeGuids) property of MS Test projects contains a specific guid
         ("3AC096D0-A1C2-E12C-1390-A8335801FDAB")
 
 
@@ -154,7 +154,7 @@
     <PropertyGroup Condition=" $(SonarQubeTestProject) == '' ">
       <!-- The MS Test project type guid-->
       <SonarQubeMsTestProjectTypeGuid>3AC096D0-A1C2-E12C-1390-A8335801FDAB</SonarQubeMsTestProjectTypeGuid>
-      <SonarQubeTestProject Condition=" $(ProjectTypeGuid.ToUpperInvariant().Contains('$(SonarQubeMsTestProjectTypeGuid)')) ">true</SonarQubeTestProject>
+      <SonarQubeTestProject Condition=" $(ProjectTypeGuids.ToUpperInvariant().Contains('$(SonarQubeMsTestProjectTypeGuid)')) ">true</SonarQubeTestProject>
     </PropertyGroup>
 
     <!-- If we haven't already determined whether the project is a test project then check

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
@@ -445,7 +445,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
   <PropertyGroup>
     <SonarQubeExclude>true</SonarQubeExclude>
     <Language>my.language</Language>
-    <ProjectTypeGuid>{4}</ProjectTypeGuid>
+    <ProjectTypeGuids>{4}</ProjectTypeGuids>
 
     <ProjectGuid>{0}</ProjectGuid>
 

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -53,7 +53,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
         // Non-SonarQube constants
         public const string ProjectGuid = "ProjectGuid";
-        public const string ProjectTypeGuid = "ProjectTypeGuid";
+        public const string ProjectTypeGuids = "ProjectTypeGuids";
 
         public const string RunCodeAnalysis = "RunCodeAnalysis";
         public const string CodeAnalysisRuleset = "CodeAnalysisRuleSet";

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/WellKnownProjectProperties.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/WellKnownProjectProperties.cs
@@ -96,8 +96,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
         public string ProjectTypeGuids
         {
-            get { return this.GetValueOrNull(TargetProperties.ProjectTypeGuid); }
-            set { this[TargetProperties.ProjectTypeGuid] = value; }
+            get { return this.GetValueOrNull(TargetProperties.ProjectTypeGuids); }
+            set { this[TargetProperties.ProjectTypeGuids] = value; }
         }
 
         #endregion


### PR DESCRIPTION
One-character change in the targets file: correct property name is "PropertyTypeGuids", not "PropertyTypeGuid".

There are existing unit and integration tests but they all used the wrong name too...