### PR TITLE
[SONARMSBRU-120] Add the FileShare.Read to the .Load command to allow multiple readers.

### DIFF
--- a/SonarQube.Common/Serializer.cs
+++ b/SonarQube.Common/Serializer.cs
@@ -66,7 +66,7 @@ namespace SonarQube.Common
             XmlSerializer ser = new XmlSerializer(typeof(T));
 
             object o = null;
-            using (FileStream fs = File.Open(fileName, FileMode.Open, FileAccess.Read))
+            using (FileStream fs = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 o = ser.Deserialize(fs);
             }


### PR DESCRIPTION
If you want to share the build server across multiple agents with the same config file you need this change. Without it the following code throws an in use exception even though it's only trying to read.

    using (File.Open(fileName, FileMode.Open, FileAccess.Read))
    using (File.Open(fileName, FileMode.Open, FileAccess.Read)  ;

the following allows multiple readers:

    using (File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
    using (File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read)  ;