### PR TITLE
[SONARMSBRU-113] Fixed issue creating .jar file in VS2015

### DIFF
--- a/PackagingProjects/CSharpPluginPayload/CSharpPluginPayload.csproj
+++ b/PackagingProjects/CSharpPluginPayload/CSharpPluginPayload.csproj
@@ -29,12 +29,14 @@
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <NoWarn>CS2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <SourcesRoot>$(MSBuildThisFileFullPath)\..\..\..</SourcesRoot>
     <DestinationDir>$(SourcesRoot)\DeploymentArtifacts\CSharpPluginPayload\$(Configuration)\</DestinationDir>
     <!-- OutputPath is required by the Clean and Rebuild tasks -->
-    <OutputPath>$(DestinationDir)</OutputPath>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>CSharpPluginPayload</AssemblyName>

--- a/PackagingProjects/CSharpPluginPayload/RepackageCSharpPlugin.ps1
+++ b/PackagingProjects/CSharpPluginPayload/RepackageCSharpPlugin.ps1
@@ -15,7 +15,7 @@ function WriteMessage
    Write-Host -ForegroundColor Green $message
 }
 
-function WriteImporantMessage
+function WriteImportantMessage
 {
    param([string][Parameter(Mandatory=$true)] $message)
 
@@ -108,13 +108,13 @@ function GetSourceJarPath
 
     if ($sourceJarPath.Count -eq 0)
     {
-        WriteImporantMessage "Before using this script please copy a CSharp plugin (the jar file) to the same directory as the script: $sourceDir"
+        WriteImportantMessage "Before using this script please copy a CSharp plugin (the jar file) to the same directory as the script: $sourceDir"
 		exit
     }
 
     if ($sourceJarPath.Count > 1)
     {
-        WriteImporantMessage "Too many jar files in the same directory as the script. Expecting only one"
+        WriteImportantMessage "Too many jar files in the same directory as the script. Expecting only one"
 		exit 
     }
 
@@ -253,7 +253,7 @@ function CreateNewJar
     [System.IO.File]::Move($destinationPath, $destinatioPathAsJar);
 
 
-    WriteImporantMessage "Success!! The jar file can be found in $destinationDir"
+    WriteImportantMessage "Success! The jar file can be found in $destinationDir"
     
 }
 

--- a/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
+++ b/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{66CE9491-1C14-45D2-BEB6-A0695C63EBB2}</ProjectGuid>

--- a/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
+++ b/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F43364BB-E460-4AC4-87E9-DE460A9F55F5}</ProjectGuid>

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/SonarQube.MSBuild.Tasks.IntegrationTests.csproj
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/SonarQube.MSBuild.Tasks.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.MSBuild.Tasks.IntegrationTests</RootNamespace>
     <AssemblyName>SonarQube.Integration.Tasks.IntegrationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>


### PR DESCRIPTION
Also fixed miscellaneous build warnings

Building in VS2015 created a .jar file twice the size of the one created when building in VS2013 due to the inclusion of various TFS dlls. The packaging project was explicitly copying the files to be include into the zip to a specific folder. However, it was also specifying this folder as the output folder for the project. This meant that all of the project dependencies were being copied into the "zip" folder.
In VS2015, the TFS2013 assemblies are considered to be dependencies that need to be copied locally since they aren't part of the VS2015 distribution.