### PR TITLE
Do not silently ignore 404 errors

### DIFF
--- a/SonarQube.Common/Resources.Designer.cs
+++ b/SonarQube.Common/Resources.Designer.cs
@@ -318,6 +318,15 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find a file on the SonarQube server. Url: {0}.
+        /// </summary>
+        internal static string ERROR_FileNotFound {
+            get {
+                return ResourceManager.GetString("ERROR_FileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Descriptor ids must be unique.
         /// </summary>
         public static string ERROR_Parser_UniqueDescriptorIds {

--- a/SonarQube.Common/Resources.resx
+++ b/SonarQube.Common/Resources.resx
@@ -236,4 +236,7 @@
   <data name="INFO_SonarVerboseWasSpecified" xml:space="preserve">
     <value>sonar.verbose={0} was specified - setting the log verbosity to '{1}'</value>
   </data>
+  <data name="ERROR_FileNotFound" xml:space="preserve">
+    <value>Could not find a file on the SonarQube server. Url: {0}</value>
+  </data>
 </root>

--- a/SonarQube.Common/Utilities.cs
+++ b/SonarQube.Common/Utilities.cs
@@ -155,6 +155,7 @@ namespace SonarQube.Common
             var response = ex.Response as HttpWebResponse;
             if (response != null && response.StatusCode == HttpStatusCode.NotFound)
             {
+                logger.LogError(Resources.ERROR_FileNotFound, response.ResponseUri);
                 return true;
             }
 


### PR DESCRIPTION
I've tested this commit by locally reverting the fix for SONARMSBRU-125: https://github.com/SonarSource/sonar-msbuild-runner/commit/6bdad3317ef6fdf7aa30d9f8fcf21047e6f3a2e7

I now get the following messages in the logs - which seems definitely better:
```
11:41:30  Generating the FxCop ruleset: C:\Users\dinesh\Desktop\tmp\ConsoleApplication1\.sonarqube\conf\SonarQubeFxCop-cs.ruleset
11:41:30  Could not find a file on the SonarQube server. Url: http://localhost:9000/api/profiles/index?language=cs&name=Sonar#way
Process returned exit code 1
Pre-processing failed. Exit code: 1
```

This relates to:
* http://jira.sonarsource.com/browse/SONARMSBRU-91
* https://github.com/SonarSource/sonar-msbuild-runner/commit/10963e597189c98f921d6b6ebc329edb18586f3f

I think the log message was missing from the beginning - can you confirm @bgavrilMS ?