### PR TITLE
[Technical] Refactored to use a parameter object for the ProcessRunner

### DIFF
--- a/SonarQube.Bootstrapper/Program.cs
+++ b/SonarQube.Bootstrapper/Program.cs
@@ -82,19 +82,30 @@ namespace SonarQube.Bootstrapper
             }
 
             var preprocessorFilePath = settings.PreProcessorFilePath;
-            var processRunner = new ProcessRunner();
-            processRunner.Execute(preprocessorFilePath, settings.ChildCmdLineArgs, settings.TempDirectory, logger);
 
-            return processRunner.ExitCode;
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(preprocessorFilePath, logger)
+            {
+                CmdLineArgs = settings.ChildCmdLineArgs,
+                WorkingDirectory = settings.TempDirectory,
+            };
+            ProcessRunner runner = new ProcessRunner();
+            runner.Execute(runnerArgs);
+
+            return runner.ExitCode;
         }
 
         private static int PostProcess(IBootstrapperSettings settings, ILogger logger)
         {
-            var postprocessorFilePath = settings.PostProcessorFilePath;
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(settings.PostProcessorFilePath, logger)
+            {
+                CmdLineArgs = settings.ChildCmdLineArgs,
+                WorkingDirectory = settings.TempDirectory
+            };
 
-            var processRunner = new ProcessRunner();
-            processRunner.Execute(postprocessorFilePath, settings.ChildCmdLineArgs, settings.TempDirectory, logger);
-            return processRunner.ExitCode;
+            ProcessRunner runner = new ProcessRunner();
+            runner.Execute(runnerArgs);
+
+            return runner.ExitCode;
         }
 
         private static void LogProcessingStarted(AnalysisPhase phase, ILogger logger)

--- a/SonarQube.Common/ProcessRunnerArgs.cs
+++ b/SonarQube.Common/ProcessRunnerArgs.cs
@@ -1,0 +1,61 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ProcessRunnerArguments.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Data class containing parameters required to execute a new process
+    /// </summary>
+    public class ProcessRunnerArguments
+    {
+        private readonly string exeName;
+        private readonly ILogger logger;
+
+        public ProcessRunnerArguments(string exeName, ILogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(exeName))
+            {
+                throw new ArgumentNullException("exeName");
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
+            }
+
+            this.exeName = exeName;
+            this.logger = logger;
+
+            this.TimeoutInMilliseconds = Timeout.Infinite;
+        }
+
+        #region Public properties
+
+        public string ExeName { get { return this.exeName; } }
+
+        /// <summary>
+        /// Non-sensitive command line arguments (i.e. ones that can safely be logged). Optional.
+        /// </summary>
+        public string CmdLineArgs { get; set; }
+
+        public string WorkingDirectory { get; set; }
+
+        public int TimeoutInMilliseconds { get; set; }
+
+        /// <summary>
+        /// Additional environments variables that should be set/overridden for the process. Can be null.
+        /// </summary>
+        public IDictionary<string, string> EnvironmentVariables { get; set; }
+
+        public ILogger Logger { get { return this.logger; } }
+
+        #endregion
+    }
+}

--- a/SonarQube.Common/SonarQube.Common.csproj
+++ b/SonarQube.Common/SonarQube.Common.csproj
@@ -50,6 +50,7 @@
     <Compile Include="CommandLine\ArgumentDescriptor.cs" />
     <Compile Include="CommandLine\CommandLineParser.cs" />
     <Compile Include="ProcessRunner.cs" />
+    <Compile Include="ProcessRunnerArgs.cs" />
     <Compile Include="ProjectInfo\AnalysisResult.cs" />
     <Compile Include="ProjectInfo\AnalysisType.cs" />
     <Compile Include="ConsoleLogger.cs" />

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -189,8 +189,16 @@ namespace SonarQube.TeamBuild.Integration
                 @"analyze /output:""{0}"" ""{1}""",
                 outputXmlFilePath, inputBinaryFilePath);
 
+
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(converterExeFilePath, logger)
+            {
+                WorkingDirectory = Path.GetDirectoryName(outputXmlFilePath),
+                CmdLineArgs = args,
+                TimeoutInMilliseconds = ConversionTimeoutInMs
+            };
+
             ProcessRunner runner = new ProcessRunner();
-            bool success = runner.Execute(converterExeFilePath, args, Path.GetDirectoryName(outputXmlFilePath), ConversionTimeoutInMs, logger);
+            bool success = runner.Execute(runnerArgs);
 
             if (success)
             {

--- a/SonarRunner.Shim/SonarRunner.Wrapper.cs
+++ b/SonarRunner.Shim/SonarRunner.Wrapper.cs
@@ -118,14 +118,15 @@ namespace SonarRunner.Shim
             IDictionary<string, string> envVarsDictionary = GetAdditionalEnvVariables(logger);
             Debug.Assert(envVarsDictionary != null);
 
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(exeFileName, logger)
+            {
+                CmdLineArgs = args,
+                WorkingDirectory = Path.GetDirectoryName(exeFileName),
+                EnvironmentVariables = envVarsDictionary
+            };
             ProcessRunner runner = new ProcessRunner();
-            bool success = runner.Execute(
-                exeFileName,
-                args,
-                Path.GetDirectoryName(exeFileName),
-                Timeout.Infinite,
-                envVarsDictionary,
-                logger);
+
+            bool success = runner.Execute(runnerArgs);
 
             success = success && !runner.ErrorsLogged;
 

--- a/Tests/SonarQube.Common.UnitTests/ProcessRunnerTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/ProcessRunnerTests.cs
@@ -28,10 +28,11 @@ namespace SonarQube.Common.UnitTests
             string exeName = TestUtils.WriteBatchFileForTest(TestContext, "exit -2");
 
             TestLogger logger = new TestLogger();
+            ProcessRunnerArguments args = new ProcessRunnerArguments(exeName, logger);
             ProcessRunner runner = new ProcessRunner();
 
             // Act
-            bool success = runner.Execute(exeName, null, null, 5000, logger);
+            bool success = runner.Execute(args);
 
             // Assert
             Assert.IsFalse(success, "Expecting the process to have failed");
@@ -49,10 +50,11 @@ xxx yyy
 ");
 
             TestLogger logger = new TestLogger();
+            ProcessRunnerArguments args = new ProcessRunnerArguments(exeName, logger);
             ProcessRunner runner = new ProcessRunner();
 
             // Act
-            bool success = runner.Execute(exeName, null, null, 1000, logger);
+            bool success = runner.Execute(args);
 
             // Assert
             Assert.IsTrue(success, "Expecting the process to have succeeded");
@@ -73,10 +75,14 @@ xxx yyy
 ");
 
             TestLogger logger = new TestLogger();
+            ProcessRunnerArguments args = new ProcessRunnerArguments(exeName, logger)
+            {
+                TimeoutInMilliseconds = 100
+            };
             ProcessRunner runner = new ProcessRunner();
 
             // Act
-            bool success = runner.Execute(exeName, null, null, 100, logger);
+            bool success = runner.Execute(args);
 
             // Assert
             Assert.IsFalse(success, "Expecting the process to have failed");
@@ -109,8 +115,13 @@ xxx yyy
                 { "PROCESS_VAR2", "PROCESS_VAR2 value" },
                 { "PROCESS_VAR3", "PROCESS_VAR3 value" } };
 
+            ProcessRunnerArguments args = new ProcessRunnerArguments(exeName, logger)
+            {
+                EnvironmentVariables = envVariables
+            };
+
             // Act
-            bool success = runner.Execute(exeName, null, null, 150, envVariables, logger);
+            bool success = runner.Execute(args);
 
             // Assert
             Assert.IsTrue(success, "Expecting the process to have succeeded");
@@ -148,9 +159,14 @@ xxx yyy
                     { "proc.runner.test.machine", "machine override" },
                     { "proc.runner.test.process", "process override" },
                     { "proc.runner.test.user", "user override" } };
-  
+
+                ProcessRunnerArguments args = new ProcessRunnerArguments(exeName, logger)
+                {
+                    EnvironmentVariables = envVariables
+                };
+
                 // Act
-                bool success = runner.Execute(exeName, null, null, 200, envVariables, logger);
+                bool success = runner.Execute(args);
 
                 // Assert
                 Assert.IsTrue(success, "Expecting the process to have succeeded");
@@ -181,10 +197,11 @@ xxx yyy
 
             // Arrange
             TestLogger logger = new TestLogger();
+            ProcessRunnerArguments args = new ProcessRunnerArguments("missingExe.foo", logger);
             ProcessRunner runner = new ProcessRunner();
 
             // Act
-            bool success = runner.Execute("missingExe.foo", null, null, 100, null, logger);
+            bool success = runner.Execute(args);
 
             // Assert
             Assert.IsFalse(success, "Expecting the process to have failed");

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/V0_9UpgradeMessageTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/V0_9UpgradeMessageTests.cs
@@ -22,10 +22,14 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
         {
             // Arrange
             TestLogger logger = new TestLogger();
+            ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(typeof(V0_9UpgradeMessageExe.Program).Assembly.Location, logger)
+            {
+                WorkingDirectory = this.TestContext.DeploymentDirectory
+            };
 
             // Act
             ProcessRunner runner = new ProcessRunner();
-            bool success = runner.Execute(typeof(V0_9UpgradeMessageExe.Program).Assembly.Location, "", this.TestContext.DeploymentDirectory, logger);
+            bool success = runner.Execute(runnerArgs);
 
             // Assert
             Assert.IsFalse(success);


### PR DESCRIPTION
No changes in behaviour. All existing tests pass.
The ProcessRunner already has six arguments and three "Execute" overloads. Not logging all arguments to the command line (SONARMSBRU-126) will add a seventh parameter.

This code review of mainly for information and to clean up the code before fixing SONARMSBRU-126.