### PR TITLE
[Technical] Changed the process runner to expect child args as a list

### DIFF
--- a/SonarQube.Bootstrapper/ArgumentProcessor.cs
+++ b/SonarQube.Bootstrapper/ArgumentProcessor.cs
@@ -147,7 +147,7 @@ namespace SonarQube.Bootstrapper
             return phase != AnalysisPhase.Unspecified;
         }
 
-        private static IBootstrapperSettings CreatePreProcessorSettings(IList<string> baseChildArgs, IAnalysisPropertyProvider properties, IAnalysisPropertyProvider globalFileProperties, ILogger logger)
+        private static IBootstrapperSettings CreatePreProcessorSettings(IList<string> childArgs, IAnalysisPropertyProvider properties, IAnalysisPropertyProvider globalFileProperties, ILogger logger)
         {
             string hostUrl = TryGetHostUrl(properties, logger);
             if (hostUrl == null)
@@ -163,10 +163,8 @@ namespace SonarQube.Bootstrapper
             {
                 Debug.Assert(fileProvider.PropertiesFile != null);
                 Debug.Assert(!string.IsNullOrEmpty(fileProvider.PropertiesFile.FilePath), "Expecting the properties file path to be set");
-                baseChildArgs.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}{1}", FilePropertyProvider.Prefix, fileProvider.PropertiesFile.FilePath));
+                childArgs.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}\"{1}\"", FilePropertyProvider.Prefix, fileProvider.PropertiesFile.FilePath));
             }
-
-            string childArgs = GetChildProcCmdLineParams(baseChildArgs);
 
             IBootstrapperSettings settings = new BootstrapperSettings(
                 AnalysisPhase.PreProcessing,
@@ -189,9 +187,8 @@ namespace SonarQube.Bootstrapper
             return null;
         }
 
-        private static IBootstrapperSettings CreatePostProcessorSettings(IList<string> baseChildArgs, IAnalysisPropertyProvider properties, ILogger logger)
+        private static IBootstrapperSettings CreatePostProcessorSettings(IList<string> childArgs, IAnalysisPropertyProvider properties, ILogger logger)
         {
-            string childArgs = GetChildProcCmdLineParams(baseChildArgs);
             IBootstrapperSettings settings = new BootstrapperSettings(
                 AnalysisPhase.PostProcessing,
                 childArgs,
@@ -220,11 +217,6 @@ namespace SonarQube.Bootstrapper
                 .Except(excludedVerbs)
                 .Where(arg => !excludedPrefixes.Any(e => arg.StartsWith(e, ArgumentDescriptor.IdComparison)))
                 .ToList();
-        }
-
-        private static string GetChildProcCmdLineParams(IList<string> args)
-        {
-            return string.Join(" ", args.Select(a => "\"" + a + "\""));
         }
 
         #endregion Private methods

--- a/SonarQube.Bootstrapper/BootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/BootstrapperSettings.cs
@@ -7,6 +7,7 @@
 
 using SonarQube.Common;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace SonarQube.Bootstrapper
@@ -66,7 +67,7 @@ namespace SonarQube.Bootstrapper
         private readonly ILogger logger;
         private readonly string sonarQubeUrl;
         private readonly AnalysisPhase analysisPhase;
-        private readonly string childCmdLineArgs;
+        private readonly IEnumerable<string> childCmdLineArgs;
 
         private string tempDir;
         private string preProcFilePath;
@@ -74,7 +75,7 @@ namespace SonarQube.Bootstrapper
         
         #region Constructor(s)
         
-        public BootstrapperSettings(AnalysisPhase phase, string childCmdLineArgs, string sonarQubeUrl, ILogger logger)
+        public BootstrapperSettings(AnalysisPhase phase, IEnumerable<string> childCmdLineArgs, string sonarQubeUrl, ILogger logger)
         {
             if (sonarQubeUrl == null)
             {
@@ -88,6 +89,7 @@ namespace SonarQube.Bootstrapper
             this.sonarQubeUrl = sonarQubeUrl;
             this.analysisPhase = phase;
             this.childCmdLineArgs = childCmdLineArgs;
+
             this.logger = logger;
         }
 
@@ -156,7 +158,7 @@ namespace SonarQube.Bootstrapper
             get { return this.analysisPhase; }
         }
 
-        public string ChildCmdLineArgs
+        public IEnumerable<string> ChildCmdLineArgs
         {
             get { return this.childCmdLineArgs; }
         }

--- a/SonarQube.Bootstrapper/Interfaces/IBootstrapperSettings.cs
+++ b/SonarQube.Bootstrapper/Interfaces/IBootstrapperSettings.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace SonarQube.Bootstrapper
 {
@@ -58,6 +59,6 @@ namespace SonarQube.Bootstrapper
         /// <summary>
         /// The command line arguments to pass to the child process
         /// </summary>
-        string ChildCmdLineArgs { get; }
+        IEnumerable<string> ChildCmdLineArgs { get; }
     }
 }

--- a/SonarQube.Common/ProcessRunner.cs
+++ b/SonarQube.Common/ProcessRunner.cs
@@ -57,7 +57,7 @@ namespace SonarQube.Common
                 UseShellExecute = false, // required if we want to capture the error output
                 ErrorDialog = false,
                 CreateNoWindow = true,
-                Arguments = runnerArgs.CmdLineArgs,
+                Arguments = runnerArgs.GetQuotedCommandLineArgs(),
                 WorkingDirectory = runnerArgs.WorkingDirectory
             };
 

--- a/SonarQube.Common/ProcessRunnerArgs.cs
+++ b/SonarQube.Common/ProcessRunnerArgs.cs
@@ -7,6 +7,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 namespace SonarQube.Common
@@ -43,7 +45,7 @@ namespace SonarQube.Common
         /// <summary>
         /// Non-sensitive command line arguments (i.e. ones that can safely be logged). Optional.
         /// </summary>
-        public string CmdLineArgs { get; set; }
+        public IEnumerable<string> CmdLineArgs { get; set; }
 
         public string WorkingDirectory { get; set; }
 
@@ -56,6 +58,36 @@ namespace SonarQube.Common
 
         public ILogger Logger { get { return this.logger; } }
 
+        public string GetQuotedCommandLineArgs()
+        {
+            if (this.CmdLineArgs != null)
+            {
+                return string.Join(" ", this.CmdLineArgs.Select(a => GetQuotedArg(a)));
+            }
+            return null;
+        }
+
         #endregion
+
+        #region Private methods
+
+        private static string GetQuotedArg(string arg)
+        {
+            Debug.Assert(arg != null, "Not expecting an argument to be null");
+
+            string quotedArg = arg;
+
+            // If an argument contains a quote then we assume it has been correctly quoted.
+            // Otherwise, quote strings that contain spaces.
+            if (quotedArg != null && arg.Contains(' ') && !arg.Contains('"'))
+            {
+                quotedArg = "\"" + arg + "\"";
+            }
+
+            return quotedArg;
+        }
+
+        #endregion
+
     }
 }

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -184,10 +184,11 @@ namespace SonarQube.TeamBuild.Integration
             Debug.Assert(Path.IsPathRooted(inputBinaryFilePath), "Expecting the input file name to be a full absolute path");
             Debug.Assert(File.Exists(inputBinaryFilePath), "Expecting the input file to exist: " + inputBinaryFilePath);
             Debug.Assert(Path.IsPathRooted(outputXmlFilePath), "Expecting the output file name to be a full absolute path");
-
-            string args = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                @"analyze /output:""{0}"" ""{1}""",
-                outputXmlFilePath, inputBinaryFilePath);
+            
+            List<string> args = new List<string>();
+            args.Add("analyze");
+            args.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, @"/output:""{0}""", outputXmlFilePath));
+            args.Add(inputBinaryFilePath);
 
 
             ProcessRunnerArguments runnerArgs = new ProcessRunnerArguments(converterExeFilePath, logger)

--- a/SonarRunner.Shim/SonarRunner.Wrapper.cs
+++ b/SonarRunner.Shim/SonarRunner.Wrapper.cs
@@ -107,11 +107,9 @@ namespace SonarRunner.Shim
 
             IgnoreSonarRunnerHome(logger);
 
-            string args = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                "-Dproject.settings=\"{0}\" {1}",
-                propertiesFileName,
-                AdditionalRunnerArguments
-                );
+            List<string> args = new List<string>();
+            args.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "-Dproject.settings=\"{0}\"", propertiesFileName));
+            args.Add(AdditionalRunnerArguments);
 
             logger.LogMessage(Resources.DIAG_CallingSonarRunner);
 

--- a/Tests/SonarQube.Bootstrapper.Tests/ArgumentProcessorTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/ArgumentProcessorTests.cs
@@ -38,9 +38,8 @@ namespace SonarQube.Bootstrapper.Tests
 
             // 1. Minimal command line settings with extra values
             IBootstrapperSettings settings = CheckProcessingSucceeds(logger, "/d:sonar.host.url=foo", "foo", "blah", "/xxxx");
-            AssertUrlAndChildCmdLineArgs(settings, "foo", "\"/d:sonar.host.url=foo\" \"foo\" \"blah\" \"/xxxx\"");
+            AssertUrlAndChildCmdLineArgs(settings, "foo", "/d:sonar.host.url=foo", "foo", "blah", "/xxxx");
         }
-
 
         [TestMethod]
         public void ArgProc_StripVerbsAndPrefixes()
@@ -48,10 +47,10 @@ namespace SonarQube.Bootstrapper.Tests
             TestLogger logger = new TestLogger();
             
             IBootstrapperSettings settings = CheckProcessingSucceeds(logger, "/d:sonar.host.url=foo", "/begin:true", "/install:true");
-            AssertUrlAndChildCmdLineArgs(settings, "foo", "\"/d:sonar.host.url=foo\" \"/begin:true\" \"/install:true\"");
+            AssertUrlAndChildCmdLineArgs(settings, "foo", "/d:sonar.host.url=foo", "/begin:true", "/install:true");
 
             settings = CheckProcessingSucceeds(logger, "/d:sonar.host.url=foo", "begin", "/installXXX:true");
-            AssertUrlAndChildCmdLineArgs(settings, "foo",  "\"/d:sonar.host.url=foo\" \"/installXXX:true\"");
+            AssertUrlAndChildCmdLineArgs(settings, "foo",  "/d:sonar.host.url=foo", "/installXXX:true");
         }
 
         [TestMethod]
@@ -287,10 +286,11 @@ namespace SonarQube.Bootstrapper.Tests
             return logger;
         }
 
-        private static void AssertUrlAndChildCmdLineArgs(IBootstrapperSettings settings, string expectedUrl, string expectedCmdLineArgs)
+        private static void AssertUrlAndChildCmdLineArgs(IBootstrapperSettings settings, string expectedUrl, params string[] expectedCmdLineArgs)
         {
             Assert.AreEqual(expectedUrl, settings.SonarQubeUrl, "Unexpected SonarQube URL");
-            Assert.AreEqual(expectedCmdLineArgs, settings.ChildCmdLineArgs, "Unexpected child command line arguments");
+
+            CollectionAssert.AreEqual(expectedCmdLineArgs, settings.ChildCmdLineArgs.ToList(), "Unexpected child command line arguments");
         }
 
         private static void AssertUrl(IBootstrapperSettings settings, string expectedUrl)
@@ -305,8 +305,7 @@ namespace SonarQube.Bootstrapper.Tests
 
         private static void AssertExpectedChildArguments(IBootstrapperSettings actualSettings, params string[] expected)
         {
-            string expectedSingleArgs = string.Join(" ", expected.Select(a => "\"" + a + "\""));
-            Assert.AreEqual(expectedSingleArgs, actualSettings.ChildCmdLineArgs, "Unexpected child command line arguments");
+            CollectionAssert.AreEqual(expected, actualSettings.ChildCmdLineArgs.ToList(), "Unexpected child command line arguments");
         }
 
         #endregion

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperExeTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperExeTests.cs
@@ -154,7 +154,10 @@ namespace SonarQube.Bootstrapper.Tests
                 logger.AssertWarningsLogged(0);
 
                 string logPath = DummyExeHelper.AssertDummyPreProcLogExists(binDir, this.TestContext);
-                DummyExeHelper.AssertExpectedLogContents(logPath, "/install:true\r\n/d:sonar.host.url=http://host:9\r\n/d:another.key=will be ignored\r\n");
+                DummyExeHelper.AssertExpectedLogContents(logPath,
+                    "/install:true",
+                    "/d:sonar.host.url=http://host:9",
+                    "/d:another.key=will be ignored");
             }
         }
 
@@ -188,7 +191,7 @@ namespace SonarQube.Bootstrapper.Tests
                 logger.AssertWarningsLogged(0);
 
                 string logPath = DummyExeHelper.AssertDummyPreProcLogExists(binDir, this.TestContext);
-                DummyExeHelper.AssertExpectedLogContents(logPath, "/d:sonar.host.url=http://anotherHost\r\n");
+                DummyExeHelper.AssertExpectedLogContents(logPath, "/d:sonar.host.url=http://anotherHost");
             }
         }
 
@@ -214,7 +217,7 @@ namespace SonarQube.Bootstrapper.Tests
                 logger.AssertWarningsLogged(0);
 
                 string logPath = DummyExeHelper.AssertDummyPostProcLogExists(binDir, this.TestContext);
-                DummyExeHelper.AssertExpectedLogContents(logPath, string.Empty);
+                DummyExeHelper.AssertExpectedLogContents(logPath, null);
             }
         }
 
@@ -242,7 +245,9 @@ namespace SonarQube.Bootstrapper.Tests
                 // The bootstrapper pass through any parameters it doesn't recognise so the post-processor
                 // can decide whether to handle them or not
                 string logPath = DummyExeHelper.AssertDummyPostProcLogExists(binDir, this.TestContext);
-                DummyExeHelper.AssertExpectedLogContents(logPath, "other params\r\nyet.more.params\r\n");
+                DummyExeHelper.AssertExpectedLogContents(logPath,
+                    "other params",
+                    "yet.more.params");
             }
         }
 
@@ -290,7 +295,11 @@ namespace SonarQube.Bootstrapper.Tests
                     mockUpdater.AssertVersionChecked();
 
                     string logPath = DummyExeHelper.AssertDummyPreProcLogExists(binDir, this.TestContext);
-                    DummyExeHelper.AssertExpectedLogContents(logPath, "/v:version\r\n/n:name\r\n/k:key\r\n/s:" + defaultPropertiesFilePath + "\r\n");
+                    DummyExeHelper.AssertExpectedLogContents(logPath,
+                        "/v:version",
+                        "/n:name",
+                        "/k:key",
+                        "/s:" + defaultPropertiesFilePath);
 
                     DummyExeHelper.AssertDummyPostProcLogDoesNotExist(binDir);
 
@@ -298,7 +307,7 @@ namespace SonarQube.Bootstrapper.Tests
                     logger = CheckExecutionSucceeds(mockUpdater);
 
                     logPath = DummyExeHelper.AssertDummyPostProcLogExists(binDir, this.TestContext);
-                    DummyExeHelper.AssertExpectedLogContents(logPath, string.Empty);
+                    DummyExeHelper.AssertExpectedLogContents(logPath, null);
 
                     logger.AssertWarningsLogged(1); // Should be warned once about the missing "begin" / "end"
                     logger.AssertSingleWarningExists(ArgumentProcessor.BeginVerb, ArgumentProcessor.EndVerb);

--- a/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
+++ b/Tests/SonarQube.Bootstrapper.Tests/BootstrapperSettingsTests.cs
@@ -7,6 +7,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarQube.Common;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using TestUtilities;
 
@@ -26,7 +27,7 @@ namespace SonarQube.Bootstrapper.Tests
         {
             string validUrl = "http://myserver";
             ILogger validLogger = new TestLogger();
-            string validArgs = string.Empty;
+            IList<string> validArgs = null;
 
             AssertException.Expects<ArgumentNullException>(() => new BootstrapperSettings(AnalysisPhase.PostProcessing, validArgs, null, validLogger));
             AssertException.Expects<ArgumentNullException>(() => new BootstrapperSettings(AnalysisPhase.PreProcessing, validArgs, validUrl, null));
@@ -45,7 +46,7 @@ namespace SonarQube.Bootstrapper.Tests
                 envScope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, @"c:\temp");
 
                 // 1. Default value -> relative to download dir
-                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, null, "http://sq", logger);
                 AssertExpectedServerUrl("http://sq", settings);
                 AssertExpectedPreProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, BootstrapperSettings.PreProcessorExeName), settings);
                 AssertExpectedPostProcessPath(Path.Combine(@"c:\temp", DownloadFolderRelativePath, BootstrapperSettings.PostProcessorExeName), settings);
@@ -64,7 +65,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, "legacy tf build");
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
 
-                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, null, "http://sq", logger);
                 AssertExpectedDownloadDir(Path.Combine("legacy tf build", DownloadFolderRelativePath), settings);
             }
 
@@ -74,7 +75,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, null);
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, "tfs build");
 
-                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, string.Empty, "http://sq", logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, null, "http://sq", logger);
                 AssertExpectedDownloadDir(Path.Combine("tfs build", DownloadFolderRelativePath), settings);
             }
 
@@ -84,7 +85,7 @@ namespace SonarQube.Bootstrapper.Tests
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_Legacy, null);
                 scope.SetVariable(BootstrapperSettings.BuildDirectory_TFS2015, null);
 
-                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, "http://sq", string.Empty, logger);
+                IBootstrapperSettings settings = new BootstrapperSettings(AnalysisPhase.PreProcessing, null, "http://sq", logger);
                 AssertExpectedDownloadDir(Path.Combine(Directory.GetCurrentDirectory(), DownloadFolderRelativePath), settings);
             }
         }

--- a/Tests/TestUtilities/DummyExeHelper.cs
+++ b/Tests/TestUtilities/DummyExeHelper.cs
@@ -25,14 +25,14 @@ namespace TestUtilities
 
         #region Public methods
 
-        public static void CreateDummyPreProcessor(string dummyBinDir, int exitCode)
+        public static string CreateDummyPreProcessor(string dummyBinDir, int exitCode)
         {
-            CreateDummyExe(dummyBinDir, PreProcessorExeName, exitCode);
+            return CreateDummyExe(dummyBinDir, PreProcessorExeName, exitCode);
         }
 
-        public static void CreateDummyPostProcessor(string dummyBinDir, int exitCode)
+        public static string CreateDummyPostProcessor(string dummyBinDir, int exitCode)
         {
-            CreateDummyExe(dummyBinDir, PostProcessorExeName, exitCode);
+            return CreateDummyExe(dummyBinDir, PostProcessorExeName, exitCode);
         }
 
         #endregion
@@ -58,13 +58,14 @@ namespace TestUtilities
         {
             return AssertLogFileDoesNotExist(dummyBinDir, PostProcessorExeName);
         }
-
-        public static void AssertExpectedLogContents(string logPath, string expected)
+        
+        public static void AssertExpectedLogContents(string logPath, params string[] expected)
         {
             Assert.IsTrue(File.Exists(logPath), "Expected log file does not exist: {0}", logPath);
 
-            string actual = File.ReadAllText(logPath);
-            Assert.AreEqual(expected, actual, "Log file does not have the expected content");
+            string[] actualLines = File.ReadAllLines(logPath);
+
+            CollectionAssert.AreEqual(expected ?? new string[] { }, actualLines, "Log file does not have the expected content");
         }
 
         private static string AssertLogFileExists(string dummyBinDir, string exeName, TestContext testContext)
@@ -128,7 +129,10 @@ namespace TestUtilities
 
             if (result.Errors.Count > 0)
             {
-                Console.WriteLine(result.Output.ToString());
+                foreach(string item in result.Output)
+                {
+                    Console.WriteLine(item);
+                }
                 Assert.Fail("Test setup error: failed to create dynamic assembly. See the test output for compiler output");
             }
         }


### PR DESCRIPTION
Previously the process runner expected a single string containing all of the child args, correctly quoted. 
The commit changes the process runner to accept a list of individual strings that it will quote as necessary. This makes it easier to centralise processing of command line arguments e.g. it will be much simpler to make the ProcessRunner filter out arguments that should not be logged such as passwords.