### PR TITLE
[Technical] Removed duplicate info from AnalysisConfig file

### DIFF
--- a/SonarQube.TeamBuild.PreProcessor/ArgumentProcessor.cs
+++ b/SonarQube.TeamBuild.PreProcessor/ArgumentProcessor.cs
@@ -154,7 +154,7 @@ namespace SonarQube.TeamBuild.PreProcessor
                 areValid = false;
             }
 
-            string projectKey = args.GetSetting(SonarProperties.ProjectKey);
+            string projectKey = args.ProjectKey;
             if (!IsValidProjectKey(projectKey))
             {
                 logger.LogError(Resources.ERROR_InvalidProjectKeyArg);

--- a/SonarQube.TeamBuild.PreProcessor/ProcessedArgs.cs
+++ b/SonarQube.TeamBuild.PreProcessor/ProcessedArgs.cs
@@ -17,7 +17,10 @@ namespace SonarQube.TeamBuild.PreProcessor
     /// </summary>
     public class ProcessedArgs
     {
-        private readonly ListPropertiesProvider projectSettingsProvider;
+        private readonly string projectKey;
+        private readonly string projectName;
+        private readonly string projectVersion;
+
         private readonly IAnalysisPropertyProvider cmdLineProperties;
         private readonly IAnalysisPropertyProvider globalFileProperties;
 
@@ -46,34 +49,27 @@ namespace SonarQube.TeamBuild.PreProcessor
                 throw new ArgumentNullException("globalFileProperties");
             }
 
+            this.projectKey = key;
+            this.projectName = name;
+            this.projectVersion = version;
+
             this.cmdLineProperties = cmdLineProperties;
             this.globalFileProperties = globalFileProperties;
             this.InstallLoaderTargets = installLoaderTargets;
 
-            this.projectSettingsProvider = new ListPropertiesProvider();
-            this.projectSettingsProvider.AddProperty(SonarProperties.ProjectKey, key);
-            this.projectSettingsProvider.AddProperty(SonarProperties.ProjectName, name);
-            this.projectSettingsProvider.AddProperty(SonarProperties.ProjectVersion, version);
-
-            this.aggProperties = new AggregatePropertiesProvider(projectSettingsProvider, cmdLineProperties, globalFileProperties);
+            this.aggProperties = new AggregatePropertiesProvider(cmdLineProperties, globalFileProperties);
         }
 
-        public string ProjectKey { get { return this.GetSetting(SonarProperties.ProjectKey); } }
+        public string ProjectKey { get { return this.projectKey; } }
 
-        public string ProjectName { get { return this.GetSetting(SonarProperties.ProjectName); } }
+        public string ProjectName { get { return this.projectName; } }
 
-        public string ProjectVersion { get { return this.GetSetting(SonarProperties.ProjectVersion); } }
+        public string ProjectVersion { get { return this.projectVersion; } }
 
         /// <summary>
         /// If true the preprocessor should copy the loader targets to a user location where MSBuild will pick them up
         /// </summary>
         public bool InstallLoaderTargets { get; private set; }
-
-        public IAnalysisPropertyProvider ProjectSettingsProvider { get { return this.projectSettingsProvider; } }
-
-        public IAnalysisPropertyProvider CmdLineProperties {  get { return this.cmdLineProperties; } }
-
-        public IAnalysisPropertyProvider GlobalFileProperties { get { return this.globalFileProperties; } }
 
         /// <summary>
         /// Returns the value for the specified setting.

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/AnalysisConfigGeneratorTests.cs
@@ -118,9 +118,10 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             // Check the config
 
             // "Public" arguments should be in the file
-            AssertExpectedAnalysisSetting(SonarProperties.ProjectKey, "key", config);
-            AssertExpectedAnalysisSetting(SonarProperties.ProjectName, "name", config);
-            AssertExpectedAnalysisSetting(SonarProperties.ProjectVersion, "1.0", config);
+            Assert.AreEqual("key", config.SonarProjectKey, "Unexpected project key");
+            Assert.AreEqual("name", config.SonarProjectName, "Unexpected project name");
+            Assert.AreEqual("1.0", config.SonarProjectVersion, "Unexpected project version");
+
             AssertExpectedAnalysisSetting(SonarProperties.HostUrl, "http://host", config);
 
             // Sensitive arguments should not be in the file

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/ArgumentProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/ArgumentProcessorTests.cs
@@ -323,7 +323,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             AssertExpectedPropertyValue("key2", "value two with spaces", result);
 
             Assert.IsNotNull(result.GetAllProperties(), "GetAllProperties should not return null");
-            Assert.AreEqual(6, result.GetAllProperties().Count(), "Unexpected number of properties");
+            Assert.AreEqual(3, result.GetAllProperties().Count(), "Unexpected number of properties");
         }
 
         [TestMethod]
@@ -429,7 +429,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
         private static void CheckProjectKeyIsValid(string projectKey)
         {
             ProcessedArgs result = CheckProcessingSucceeds("/key:" + projectKey, "/name:valid name", "/version:1.0", "/d:sonar.host.url=http://valid");
-            AssertExpectedPropertyValue(SonarProperties.ProjectKey, projectKey, result);
+            Assert.AreEqual(projectKey, result.ProjectKey, "Unexpected project key");
         }
 
         private static ProcessedArgs CheckProcessingSucceeds(params string[] commandLineArgs)

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
@@ -100,11 +100,11 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             AssertConfigFileExists(settings.AnalysisConfigFilePath);
             AnalysisConfig actualConfig = AnalysisConfig.Load(settings.AnalysisConfigFilePath);
 
-            AssertExpectedAnalysisSetting("sonar.projectKey", "key", actualConfig);
-            AssertExpectedAnalysisSetting("sonar.projectName", "name", actualConfig);
-            AssertExpectedAnalysisSetting("sonar.projectVersion", "1.0", actualConfig);
-            AssertExpectedAnalysisSetting(SonarProperties.HostUrl, "http://host", actualConfig);
+            Assert.AreEqual("key", actualConfig.SonarProjectKey, "Unexpected project key");
+            Assert.AreEqual("name", actualConfig.SonarProjectName, "Unexpected project name");
+            Assert.AreEqual("1.0", actualConfig.SonarProjectVersion, "Unexpected project version");
 
+            AssertExpectedAnalysisSetting(SonarProperties.HostUrl, "http://host", actualConfig);
             AssertExpectedAnalysisSetting("cmd.line1", "cmdline.value.1", actualConfig);
             AssertExpectedAnalysisSetting("server.key", "server value 1", actualConfig);
         }


### PR DESCRIPTION
Fixed up existing unit tests.

The key, name and value were all being written to the AnalysisConfig as named elements and as <AdditionalSetting>s. This change removes that duplication and fixes up the existing unit tests.