### PR TITLE
[Technical] Changed settings storage

### DIFF
--- a/SonarQube.Common/AnalysisConfig/AnalysisConfig.cs
+++ b/SonarQube.Common/AnalysisConfig/AnalysisConfig.cs
@@ -37,12 +37,21 @@ namespace SonarQube.Common
         public string SonarProjectName { get; set; }
 
         /// <summary>
-        /// List of additional analysis settings
+        /// List of additional configuration-related settings
+        /// e.g. the build system identifier, if appropriate.
         /// </summary>
-        public List<AnalysisSetting> AdditionalSettings { get; set; }
+        /// <remarks>These settings will not be supplied to the sonar-runner.</remarks>
+        public List<ConfigSetting> AdditionalConfig { get; set; }
 
+        /// <summary>
+        /// List of analysis settings inherited from the SonarQube server
+        /// </summary>
         public AnalysisProperties ServerSettings{ get; set; }
 
+        /// <summary>
+        /// List of analysis settings supplied locally (either on the
+        /// command line or in a file)
+        /// </summary>
         public AnalysisProperties LocalSettings { get; set; }
 
         #endregion

--- a/SonarQube.Common/AnalysisConfig/AnalysisConfig.cs
+++ b/SonarQube.Common/AnalysisConfig/AnalysisConfig.cs
@@ -35,11 +35,15 @@ namespace SonarQube.Common
         public string SonarProjectVersion { get; set; }
 
         public string SonarProjectName { get; set; }
-        
+
         /// <summary>
         /// List of additional analysis settings
         /// </summary>
         public List<AnalysisSetting> AdditionalSettings { get; set; }
+
+        public AnalysisProperties ServerSettings{ get; set; }
+
+        public AnalysisProperties LocalSettings { get; set; }
 
         #endregion
 

--- a/SonarQube.Common/AnalysisConfig/AnalysisConfigExtensions.cs
+++ b/SonarQube.Common/AnalysisConfig/AnalysisConfigExtensions.cs
@@ -69,14 +69,6 @@ namespace SonarQube.Common
         /// <summary>
         /// Sets the value of the additional setting. The setting will be added if it does not already exist.
         /// </summary>
-        public static void SetInheritedValue(this AnalysisConfig config, string settingId, string value)
-        {
-            SetValue(config, settingId, value, true);
-        }
-
-        /// <summary>
-        /// Sets the value of the additional setting. The setting will be added if it does not already exist.
-        /// </summary>
         public static void SetExplicitValue(this AnalysisConfig config, string settingId, string value)
         {
             SetValue(config, settingId, value, false);

--- a/SonarQube.Common/AnalysisConfig/AnalysisConfigExtensions.cs
+++ b/SonarQube.Common/AnalysisConfig/AnalysisConfigExtensions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace SonarQube.Common
@@ -35,7 +36,7 @@ namespace SonarQube.Common
             string result = defaultValue;
 
             ConfigSetting setting;
-            if (config.TryGetSetting(settingId, out setting))
+            if (config.TryGetConfigSetting(settingId, out setting))
             {
                 result = setting.Value;
             }
@@ -98,16 +99,10 @@ namespace SonarQube.Common
         /// Attempts to find and return the config setting with the specified id
         /// </summary>
         /// <returns>True if the setting was found, otherwise false</returns>
-        private static bool TryGetSetting(this AnalysisConfig config, string settingId, out ConfigSetting result)
+        private static bool TryGetConfigSetting(this AnalysisConfig config, string settingId, out ConfigSetting result)
         {
-            if (config == null)
-            {
-                throw new ArgumentNullException("config");
-            }
-            if (string.IsNullOrWhiteSpace(settingId))
-            {
-                throw new ArgumentNullException("settingId");
-            }
+            Debug.Assert(config != null, "Supplied config should not be null");
+            Debug.Assert(!string.IsNullOrWhiteSpace(settingId), "Setting id should not be null/empty");
 
             result = null;
 
@@ -133,7 +128,7 @@ namespace SonarQube.Common
             }
 
             ConfigSetting setting;
-            if (config.TryGetSetting(settingId, out setting))
+            if (config.TryGetConfigSetting(settingId, out setting))
             {
                 setting.Value = value;
             }

--- a/SonarQube.Common/AnalysisConfig/ConfigSetting.cs
+++ b/SonarQube.Common/AnalysisConfig/ConfigSetting.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="AnalysisSetting.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="ConfigSetting.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -16,14 +16,13 @@ namespace SonarQube.Common
     /// Data class to describe an additional analysis configuration setting
     /// /// </summary>
     /// <remarks>The class is XML-serializable</remarks>
-    public class AnalysisSetting
+    public class ConfigSetting
     {
         #region Data
 
         /// <summary>
         /// The identifier for the setting
         /// </summary>
-        /// <remarks>Each type </remarks>
         [XmlAttribute]
         public string Id { get; set; }
 
@@ -33,36 +32,10 @@ namespace SonarQube.Common
         [XmlAttribute]
         public string Value { get; set; }
 
-        /// <summary>
-        /// Whether or not this settings was inherited from SonarQube's portal
-        /// </summary>
-        [XmlAttribute]
-        public bool Inherited { get; set; }
-
         #endregion
 
         #region Static helper methods
 
-        /// <summary>
-        /// Regular expression to validate setting ids.
-        /// </summary>
-        /// <remarks>
-        /// Validation rules:
-        /// Must start with an alpanumeric character.
-        /// Can be followed by any number of alphanumeric characters or .
-        /// Whitespace is not allowed
-        /// </remarks>
-        private static readonly Regex ValidSettingKeyRegEx = new Regex(@"^\w[\w\d\.-]*$", RegexOptions.Compiled);
-
-        /// <summary>
-        /// Returns true if the supplied string is a valid key for a sonar-XXX.properties file, otherwise false
-        /// </summary>
-        public static bool IsValidKey(string key)
-        {
-            bool isValid = ValidSettingKeyRegEx.IsMatch(key);
-            return isValid;
-        }
-        
         /// <summary>
         /// Comparer to use when comparing keys of analysis settings
         /// </summary>

--- a/SonarQube.Common/AnalysisProperties/Property.cs
+++ b/SonarQube.Common/AnalysisProperties/Property.cs
@@ -51,7 +51,27 @@ namespace SonarQube.Common
         public const string KeyValuePropertyPattern = @"^(?<key>\w[\w\d\.-]*)=(?<value>[^\r\n]+)";
 
         private static readonly Regex SingleLinePropertyRegEx = new Regex(KeyValuePropertyPattern, RegexOptions.Compiled);
-        
+
+        /// <summary>
+        /// Regular expression to validate setting ids.
+        /// </summary>
+        /// <remarks>
+        /// Validation rules:
+        /// Must start with an alpanumeric character.
+        /// Can be followed by any number of alphanumeric characters or .
+        /// Whitespace is not allowed
+        /// </remarks>
+        private static readonly Regex ValidSettingKeyRegEx = new Regex(@"^\w[\w\d\.-]*$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns true if the supplied string is a valid key for a sonar-XXX.properties file, otherwise false
+        /// </summary>
+        public static bool IsValidKey(string key)
+        {
+            bool isValid = ValidSettingKeyRegEx.IsMatch(key);
+            return isValid;
+        }
+
         /// <summary>
         /// Attempts to parse the supplied string into a key and value
         /// </summary>

--- a/SonarQube.Common/ProjectInfo/ProjectInfo.cs
+++ b/SonarQube.Common/ProjectInfo/ProjectInfo.cs
@@ -85,7 +85,7 @@ namespace SonarQube.Common
         /// <summary>
         /// List of additional analysis settings
         /// </summary>
-        public List<ConfigSetting> AnalysisSettings { get; set; }
+        public AnalysisProperties AnalysisSettings { get; set; }
 
         #endregion
 

--- a/SonarQube.Common/ProjectInfo/ProjectInfo.cs
+++ b/SonarQube.Common/ProjectInfo/ProjectInfo.cs
@@ -85,7 +85,7 @@ namespace SonarQube.Common
         /// <summary>
         /// List of additional analysis settings
         /// </summary>
-        public List<AnalysisSetting> AnalysisSettings { get; set; }
+        public List<ConfigSetting> AnalysisSettings { get; set; }
 
         #endregion
 

--- a/SonarQube.Common/ProjectInfo/ProjectInfoExtensions.cs
+++ b/SonarQube.Common/ProjectInfo/ProjectInfoExtensions.cs
@@ -53,7 +53,7 @@ namespace SonarQube.Common
         /// Attempts to find and return the analysis setting with the specified id
         /// </summary>
         /// <returns>True if the setting was found, otherwise false</returns>
-        public static bool TryGetAnalysisSetting(this ProjectInfo projectInfo, string id, out ConfigSetting result)
+        public static bool TryGetAnalysisSetting(this ProjectInfo projectInfo, string id, out Property result)
         {
             if (projectInfo == null)
             {
@@ -64,7 +64,7 @@ namespace SonarQube.Common
 
             if (projectInfo.AnalysisSettings != null)
             {
-                result = projectInfo.AnalysisSettings.FirstOrDefault(ar => ConfigSetting.SettingKeyComparer.Equals(id, ar.Id));
+                result = projectInfo.AnalysisSettings.FirstOrDefault(ar => Property.PropertyKeyComparer.Equals(id, ar.Id));
             }
             return result != null;
         }

--- a/SonarQube.Common/ProjectInfo/ProjectInfoExtensions.cs
+++ b/SonarQube.Common/ProjectInfo/ProjectInfoExtensions.cs
@@ -53,7 +53,7 @@ namespace SonarQube.Common
         /// Attempts to find and return the analysis setting with the specified id
         /// </summary>
         /// <returns>True if the setting was found, otherwise false</returns>
-        public static bool TryGetAnalysisSetting(this ProjectInfo projectInfo, string id, out AnalysisSetting result)
+        public static bool TryGetAnalysisSetting(this ProjectInfo projectInfo, string id, out ConfigSetting result)
         {
             if (projectInfo == null)
             {
@@ -64,7 +64,7 @@ namespace SonarQube.Common
 
             if (projectInfo.AnalysisSettings != null)
             {
-                result = projectInfo.AnalysisSettings.FirstOrDefault(ar => AnalysisSetting.SettingKeyComparer.Equals(id, ar.Id));
+                result = projectInfo.AnalysisSettings.FirstOrDefault(ar => ConfigSetting.SettingKeyComparer.Equals(id, ar.Id));
             }
             return result != null;
         }

--- a/SonarQube.Common/SonarQube.Common.csproj
+++ b/SonarQube.Common/SonarQube.Common.csproj
@@ -42,7 +42,7 @@
     <Compile Include="..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
-    <Compile Include="AnalysisConfig\AnalysisSetting.cs" />
+    <Compile Include="AnalysisConfig\ConfigSetting.cs" />
     <Compile Include="AnalysisConfig\AnalysisConfigExtensions.cs" />
     <Compile Include="AnalysisProperties\EmptyPropertyProvider.cs" />
     <Compile Include="AnalysisProperties\ListSettingsProvider.cs" />

--- a/SonarQube.Common/VerbosityCalculator.cs
+++ b/SonarQube.Common/VerbosityCalculator.cs
@@ -61,28 +61,6 @@ namespace SonarQube.Common
             return ComputeVerbosity(sonarVerboseValue, sonarLogLevelValue, logger);
         }
 
-        /// <summary>
-        /// Computes verbosity based on the analysis config file settings. 
-        /// </summary>
-        /// <remarks>If no verbosity setting is present, the default verbosity (info) is used</remarks>
-        public static LoggerVerbosity ComputeVerbosity(AnalysisConfig config, ILogger logger)
-        {
-            if (config == null)
-            {
-                throw new ArgumentNullException("config");
-            }
-
-            if (logger == null)
-            {
-                throw new ArgumentNullException("logger");
-            }
-
-            string sonarVerboseSettingValue = config.GetSetting(SonarProperties.Verbose, String.Empty);
-            string sonarLogLevelSettingValue = config.GetSetting(SonarProperties.LogLevel, String.Empty);
-
-            return ComputeVerbosity(sonarVerboseSettingValue, sonarLogLevelSettingValue, logger);
-        }
-
         private static LoggerVerbosity ComputeVerbosity(string sonarVerboseValue, string sonarLogValue, ILogger logger)
         {
             if (!String.IsNullOrWhiteSpace(sonarVerboseValue))

--- a/SonarQube.MSBuild.Tasks/IsTestFileByName.cs
+++ b/SonarQube.MSBuild.Tasks/IsTestFileByName.cs
@@ -90,13 +90,9 @@ namespace SonarQube.MSBuild.Tasks
         {
             Debug.Assert(config != null, "Not expecting the supplied config to be null");
 
-            AnalysisSetting setting;
-            string regEx = null;
-            if (config.TryGetSetting(TestRegExSettingId, out setting))
-            {
-                regEx = setting.Value;
-            }
-
+            string regEx;
+            config.GetAnalysisSettings(true).TryGetValue(TestRegExSettingId, out regEx);
+            
             if (!string.IsNullOrWhiteSpace(regEx))
             {
                 this.Log.LogMessage(MessageImportance.Low, Resources.IsTest_UsingRegExFromConfig, regEx);

--- a/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -152,17 +152,17 @@ namespace SonarQube.MSBuild.Tasks
         }
 
         /// <summary>
-        /// Attempts to convert the supplied task items into a list of <see cref="AnalysisSetting"/> objects
+        /// Attempts to convert the supplied task items into a list of <see cref="ConfigSetting"/> objects
         /// </summary>
-        private List<AnalysisSetting> TryCreateAnalysisSettings(ITaskItem[] resultItems)
+        private List<ConfigSetting> TryCreateAnalysisSettings(ITaskItem[] resultItems)
         {
-            List<AnalysisSetting> settings = new List<AnalysisSetting>();
+            List<ConfigSetting> settings = new List<ConfigSetting>();
 
             if (resultItems != null)
             {
                 foreach (ITaskItem resultItem in resultItems)
                 {
-                    AnalysisSetting result = TryCreateSettingFromItem(resultItem);
+                    ConfigSetting result = TryCreateSettingFromItem(resultItem);
                     if (result != null)
                     {
                         settings.Add(result);
@@ -173,14 +173,14 @@ namespace SonarQube.MSBuild.Tasks
         }
 
         /// <summary>
-        /// Attempts to create an <see cref="AnalysisSetting"/> from the supplied task item.
+        /// Attempts to create an <see cref="ConfigSetting"/> from the supplied task item.
         /// Returns null if the task item does not have the required metadata.
         /// </summary>
-        private AnalysisSetting TryCreateSettingFromItem(ITaskItem taskItem)
+        private ConfigSetting TryCreateSettingFromItem(ITaskItem taskItem)
         {
             Debug.Assert(taskItem != null, "Supplied task item should not be null");
 
-            AnalysisSetting setting = null;
+            ConfigSetting setting = null;
 
             string settingId;
 
@@ -192,7 +192,7 @@ namespace SonarQube.MSBuild.Tasks
 
                 if (TryGetSettingValue(taskItem, out settingValue))
                 {
-                    setting = new AnalysisSetting()
+                    setting = new ConfigSetting()
                     {
                         Id = settingId,
                         Value = settingValue
@@ -212,7 +212,7 @@ namespace SonarQube.MSBuild.Tasks
 
             string possibleKey = taskItem.ItemSpec;
 
-            bool isValid = AnalysisSetting.IsValidKey(possibleKey);
+            bool isValid = Property.IsValidKey(possibleKey);
             if (isValid)
             {
                 settingId = possibleKey;

--- a/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/SonarQube.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -154,15 +154,15 @@ namespace SonarQube.MSBuild.Tasks
         /// <summary>
         /// Attempts to convert the supplied task items into a list of <see cref="ConfigSetting"/> objects
         /// </summary>
-        private List<ConfigSetting> TryCreateAnalysisSettings(ITaskItem[] resultItems)
+        private AnalysisProperties TryCreateAnalysisSettings(ITaskItem[] resultItems)
         {
-            List<ConfigSetting> settings = new List<ConfigSetting>();
+            AnalysisProperties settings = new AnalysisProperties();
 
             if (resultItems != null)
             {
                 foreach (ITaskItem resultItem in resultItems)
                 {
-                    ConfigSetting result = TryCreateSettingFromItem(resultItem);
+                    Property result = TryCreateSettingFromItem(resultItem);
                     if (result != null)
                     {
                         settings.Add(result);
@@ -176,11 +176,11 @@ namespace SonarQube.MSBuild.Tasks
         /// Attempts to create an <see cref="ConfigSetting"/> from the supplied task item.
         /// Returns null if the task item does not have the required metadata.
         /// </summary>
-        private ConfigSetting TryCreateSettingFromItem(ITaskItem taskItem)
+        private Property TryCreateSettingFromItem(ITaskItem taskItem)
         {
             Debug.Assert(taskItem != null, "Supplied task item should not be null");
 
-            ConfigSetting setting = null;
+            Property setting = null;
 
             string settingId;
 
@@ -192,7 +192,7 @@ namespace SonarQube.MSBuild.Tasks
 
                 if (TryGetSettingValue(taskItem, out settingValue))
                 {
-                    setting = new ConfigSetting()
+                    setting = new Property()
                     {
                         Id = settingId,
                         Value = settingValue

--- a/SonarQube.TeamBuild.Integration/TeamBuildAnalysisSettings.cs
+++ b/SonarQube.TeamBuild.Integration/TeamBuildAnalysisSettings.cs
@@ -21,22 +21,22 @@ namespace SonarQube.TeamBuild.Integration
 
         public static string GetTfsUri(this AnalysisConfig config)
         {
-            return config.GetSetting(TfsUriSettingId, null);
+            return config.GetConfigValue(TfsUriSettingId, null);
         }
 
         public static void SetTfsUri(this AnalysisConfig config, string uri)
         {
-            config.SetExplicitValue(TfsUriSettingId, uri);
+            config.SetConfigValue(TfsUriSettingId, uri);
         }
 
         public static string GetBuildUri(this AnalysisConfig config)
         {
-            return config.GetSetting(BuildUriSettingId, null);
+            return config.GetConfigValue(BuildUriSettingId, null);
         }
 
         public static void SetBuildUri(this AnalysisConfig config, string uri)
         {
-            config.SetExplicitValue(BuildUriSettingId, uri);
+            config.SetConfigValue(BuildUriSettingId, uri);
         }
 
         #endregion

--- a/SonarQube.TeamBuild.PostProcessor/Program.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Program.cs
@@ -29,7 +29,7 @@ namespace SonarQube.TeamBuild.PostProcessor
 
             AnalysisConfig config = GetAnalysisConfig(settings, logger);
 
-            logger.Verbosity = VerbosityCalculator.ComputeVerbosity(config, logger);
+            logger.Verbosity = VerbosityCalculator.ComputeVerbosity(config.GetAnalysisSettings(true), logger);
 
             if (config == null)
             {

--- a/SonarRunner.Shim/PropertiesFileGenerator.cs
+++ b/SonarRunner.Shim/PropertiesFileGenerator.cs
@@ -58,7 +58,6 @@ namespace SonarRunner.Shim
             if (validProjects.Any())
             {
                 // Handle global settings
-                Debug.Assert(config.LocalSettings != null);
                 writer.WriteGlobalSettings(config.LocalSettings ?? new AnalysisProperties());
 
                 string contents = writer.Flush();

--- a/SonarRunner.Shim/PropertiesFileGenerator.cs
+++ b/SonarRunner.Shim/PropertiesFileGenerator.cs
@@ -58,8 +58,8 @@ namespace SonarRunner.Shim
             if (validProjects.Any())
             {
                 // Handle global settings
-                Debug.Assert(config.AdditionalSettings != null);
-                writer.WriteGlobalSettings(config.AdditionalSettings ?? Enumerable.Empty<AnalysisSetting>());
+                Debug.Assert(config.LocalSettings != null);
+                writer.WriteGlobalSettings(config.LocalSettings ?? new AnalysisProperties());
 
                 string contents = writer.Flush();
 

--- a/SonarRunner.Shim/PropertiesWriter.cs
+++ b/SonarRunner.Shim/PropertiesWriter.cs
@@ -163,7 +163,7 @@ namespace SonarRunner.Shim
 
             if (project.AnalysisSettings != null && project.AnalysisSettings.Any())
             {
-                foreach(AnalysisSetting setting in project.AnalysisSettings)
+                foreach(ConfigSetting setting in project.AnalysisSettings)
                 {
                     sb.AppendFormat("{0}.{1}={2}", guid, setting.Id, Escape(setting.Value));
                     sb.AppendLine();

--- a/SonarRunner.Shim/PropertiesWriter.cs
+++ b/SonarRunner.Shim/PropertiesWriter.cs
@@ -163,7 +163,7 @@ namespace SonarRunner.Shim
 
             if (project.AnalysisSettings != null && project.AnalysisSettings.Any())
             {
-                foreach(ConfigSetting setting in project.AnalysisSettings)
+                foreach(Property setting in project.AnalysisSettings)
                 {
                     sb.AppendFormat("{0}.{1}={2}", guid, setting.Id, Escape(setting.Value));
                     sb.AppendLine();

--- a/SonarRunner.Shim/PropertiesWriter.cs
+++ b/SonarRunner.Shim/PropertiesWriter.cs
@@ -175,19 +175,16 @@ namespace SonarRunner.Shim
         /// <summary>
         /// Write the supplied global settings into the file
         /// </summary>
-        public void WriteGlobalSettings(IEnumerable<AnalysisSetting> settings)
+        public void WriteGlobalSettings(AnalysisProperties properties)
         {
-            if (settings == null)
+            if (properties == null)
             {
-                throw new ArgumentNullException("settings");
+                throw new ArgumentNullException("properties");
             }
 
-            foreach(AnalysisSetting setting in settings)
+            foreach(Property setting in properties)
             {
-                if (!setting.Inherited)
-                {
-                    AppendKeyValue(this.sb, setting.Id, setting.Value);
-                }
+                AppendKeyValue(this.sb, setting.Id, setting.Value);
             }
             sb.AppendLine();
         }

--- a/Tests/SonarQube.Common.UnitTests/AnalysisConfigExtensionsTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/AnalysisConfigExtensionsTests.cs
@@ -1,0 +1,123 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AnalysisConfigExtensionsTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace SonarQube.Common.UnitTests
+{
+    [TestClass]
+    public class AnalysisConfigExtensionsTests
+    {
+
+        #region Tests
+
+        [TestMethod]
+        [Description("Checks the extension methods for getting and setting values")]
+        public void ConfigExt_GetAndSet()
+        {
+            // 0. Setup
+            AnalysisConfig config = new AnalysisConfig();
+
+            string result;
+
+            // 1. Get missing setting -> default returned
+            result = config.GetConfigValue("missing", "123");
+            Assert.AreEqual("123", result, "Unexpected config value returned");
+
+            // 2. Set and get a new setting
+            config.SetConfigValue("id1", "value1");
+            Assert.AreEqual("value1", config.GetConfigValue("id1", "XXX"), "Unexpected config value returned");
+
+            // 3. Update an existing setting
+            config.SetConfigValue("id1", "value2");
+            Assert.AreEqual("value2", config.GetConfigValue("id1", "XXX"), "Unexpected config value returned");
+        }
+
+
+        [TestMethod]
+        public void ConfigExt_GetAnalysisSettings()
+        {
+            // 0. Setup
+            AnalysisConfig config = new AnalysisConfig();
+
+            config.LocalSettings = new AnalysisProperties();
+            config.LocalSettings.Add(new Property() { Id = "local.1", Value = "local.value.1" });
+            config.LocalSettings.Add(new Property() { Id = "local.2", Value = "local.value.2" });
+            config.LocalSettings.Add(new Property() { Id = "shared.property", Value = "shared value from local" });
+
+            config.ServerSettings = new AnalysisProperties();
+            config.ServerSettings.Add(new Property() { Id = "server.1", Value = "server.value.1" });
+            config.ServerSettings.Add(new Property() { Id = "server.2", Value = "server.value.2" });
+            config.ServerSettings.Add(new Property() { Id = "shared.property", Value = "shared value from server - should never be returned" });
+
+            // 1. Local only
+            IAnalysisPropertyProvider localProperties = config.GetAnalysisSettings(false);
+            AssertExpectedPropertyCount(3, localProperties);
+            AssertExpectedValue("local.1", "local.value.1", localProperties);
+            AssertExpectedValue("local.2", "local.value.2", localProperties);
+            AssertExpectedValue("shared.property", "shared value from local", localProperties);
+
+            AssertPropertyDoesNotExist("server.1", localProperties);
+            AssertPropertyDoesNotExist("server.2", localProperties);
+
+            // 2. Server too
+            IAnalysisPropertyProvider allProperties = config.GetAnalysisSettings(true);
+            AssertExpectedPropertyCount(5, allProperties);
+            AssertExpectedValue("local.1", "local.value.1", allProperties);
+            AssertExpectedValue("local.2", "local.value.2", allProperties);
+            AssertExpectedValue("shared.property", "shared value from local", allProperties);
+            AssertExpectedValue("server.1", "server.value.1", allProperties);
+            AssertExpectedValue("server.2", "server.value.2", allProperties);
+        }
+
+        [TestMethod]
+        public void ConfigExt_GetAnalysisSettings_NoSettings()
+        {
+            // 0. Setup
+            AnalysisConfig config = new AnalysisConfig();
+
+            // 1. No server settings
+            IAnalysisPropertyProvider provider = config.GetAnalysisSettings(false);
+            Assert.IsNotNull(provider, "Returned provider should not be null");
+            AssertExpectedPropertyCount(0, provider);
+
+            // 2. With server settings
+            provider = config.GetAnalysisSettings(true);
+            Assert.IsNotNull(provider, "Returned provider should not be null");
+            AssertExpectedPropertyCount(0, provider);
+        }
+
+        #endregion
+
+        #region Checks
+
+        private static void AssertExpectedPropertyCount(int expected, IAnalysisPropertyProvider actualProvider)
+        {
+            Assert.AreEqual(expected, actualProvider.GetAllProperties().Count(), "Unexpected number of properties");
+        }
+
+        private static void AssertPropertyDoesNotExist(string key, IAnalysisPropertyProvider provider)
+        {
+            Property property;
+            bool found = provider.TryGetProperty(key, out property);
+            Assert.IsFalse(found, "Not expecting the property to be found. Key: {0}", key);
+        }
+
+        private static void AssertExpectedValue(string key, string expectedValue, IAnalysisPropertyProvider provider)
+        {
+            Property property;
+            bool found = provider.TryGetProperty(key, out property);
+            
+            Assert.IsTrue(found, "Expected property not found. Key: {0}", key);
+            Assert.AreEqual(expectedValue, property.Value, "Property does not have the expected value. Key: {0}", key);
+        }
+
+        #endregion
+
+    }
+}

--- a/Tests/SonarQube.Common.UnitTests/AnalysisConfigTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/AnalysisConfigTests.cs
@@ -54,6 +54,13 @@ namespace SonarQube.Common.UnitTests
             originalConfig.SonarProjectName = @"My project";
             originalConfig.SonarProjectVersion = @"1.0";
 
+
+            originalConfig.LocalSettings = new AnalysisProperties();
+            originalConfig.LocalSettings.Add(new Property() { Id = "local.key", Value = "local.value" });
+
+            originalConfig.ServerSettings = new AnalysisProperties();
+            originalConfig.ServerSettings.Add(new Property() { Id = "server.key", Value = "server.value" });
+
             string fileName = Path.Combine(testFolder, "config1.xml");
 
             SaveAndReloadConfig(originalConfig, fileName);
@@ -61,7 +68,7 @@ namespace SonarQube.Common.UnitTests
 
         [TestMethod]
         [Description("Checks additional analysis settings can be serialized and deserialized")]
-        public void ProjectInfo_Serialization_AdditionalSettings()
+        public void AnalysisConfig_Serialization_AdditionalConfig()
         {
             // 0. Setup
             string testFolder = TestUtils.CreateTestSpecificFolder(this.TestContext);
@@ -72,43 +79,14 @@ namespace SonarQube.Common.UnitTests
             SaveAndReloadConfig(originalConfig, Path.Combine(testFolder, "AnalysisConfig_NullAdditionalSettings.xml"));
 
             // 2. Empty list
-            originalConfig.AdditionalSettings = new List<AnalysisSetting>();
+            originalConfig.AdditionalConfig = new List<ConfigSetting>();
             SaveAndReloadConfig(originalConfig, Path.Combine(testFolder, "AnalysisConfig_EmptyAdditionalSettings.xml"));
 
             // 3. Non-empty list
-            originalConfig.AdditionalSettings.Add(new AnalysisSetting() { Id = string.Empty, Value = string.Empty }); // empty item
-            originalConfig.AdditionalSettings.Add(new AnalysisSetting() { Id = "Id1", Value = "http://www.foo.xxx" });
-            originalConfig.AdditionalSettings.Add(new AnalysisSetting() { Id = "Id2", Value = "value 2" });
+            originalConfig.AdditionalConfig.Add(new ConfigSetting() { Id = string.Empty, Value = string.Empty }); // empty item
+            originalConfig.AdditionalConfig.Add(new ConfigSetting() { Id = "Id1", Value = "http://www.foo.xxx" });
+            originalConfig.AdditionalConfig.Add(new ConfigSetting() { Id = "Id2", Value = "value 2" });
             SaveAndReloadConfig(originalConfig, Path.Combine(testFolder, "AnalysisConfig_NonEmptyList.xml"));
-        }
-
-        [TestMethod]
-        [Description("Checks the extension methods for getting and setting values")]
-        public void ProjectInfo_ExtensionMethods_GetAndSet()
-        {
-            // 0. Setup
-            AnalysisConfig config = new AnalysisConfig();
-
-            AnalysisSetting setting;
-            string result;
-
-            // 1. Get/TryGet missing setting
-            result = config.GetSetting("missing", "123");
-
-            Assert.IsFalse(config.TryGetSetting("missing", out setting), "Setting should not have been found");
-            Assert.AreEqual("123", config.GetSetting("missing", "123"), "Expecting the default setting to be returned");
-
-            // 2. Set and get a previously new setting
-            config.SetExplicitValue("id1", "value1");
-            Assert.IsTrue(config.TryGetSetting("id1", out setting), "Setting should have been found");
-            Assert.AreEqual("value1", setting.Value, "Unexpected value returned for setting");
-            Assert.AreEqual("value1", config.GetSetting("id1", "123"), "Unexpected value returned for setting");
-
-            // 3. Update and refetch the setting
-            config.SetExplicitValue("id1", "updated value");
-            Assert.IsTrue(config.TryGetSetting("id1", out setting), "Setting should have been found");
-            Assert.AreEqual("updated value", setting.Value, "Unexpected value returned for setting");
-            Assert.AreEqual("updated value", config.GetSetting("id1", "123"), "Unexpected value returned for setting");        
         }
 
         [TestMethod]
@@ -161,26 +139,26 @@ namespace SonarQube.Common.UnitTests
 
         private static void CompareAdditionalSettings(AnalysisConfig expected, AnalysisConfig actual)
         {
-            Assert.IsNotNull(actual.AdditionalSettings, "Not expecting the AdditionalSettings to be null for a reloaded file");
+            Assert.IsNotNull(actual.AdditionalConfig, "Not expecting the AdditionalSettings to be null for a reloaded file");
 
-            if (expected.AdditionalSettings == null || expected.AdditionalSettings.Count == 0)
+            if (expected.AdditionalConfig == null || expected.AdditionalConfig.Count == 0)
             {
-                Assert.AreEqual(0, actual.AdditionalSettings.Count, "Not expecting any additional items. Count: {0}", actual.AdditionalSettings.Count);
+                Assert.AreEqual(0, actual.AdditionalConfig.Count, "Not expecting any additional items. Count: {0}", actual.AdditionalConfig.Count);
                 return;
             }
 
-            foreach(AnalysisSetting expectedSetting in expected.AdditionalSettings)
+            foreach(ConfigSetting expectedSetting in expected.AdditionalConfig)
             {
                 AssertSettingExists(expectedSetting.Id, expectedSetting.Value, actual);
             }
-            Assert.AreEqual(expected.AdditionalSettings.Count, actual.AdditionalSettings.Count, "Unexpected number of additional settings");
+            Assert.AreEqual(expected.AdditionalConfig.Count, actual.AdditionalConfig.Count, "Unexpected number of additional settings");
         }
 
         private static void AssertSettingExists(string settingId, string expectedValue, AnalysisConfig actual)
         {
-            Assert.IsNotNull(actual.AdditionalSettings, "Not expecting the additional settings to be null");
+            Assert.IsNotNull(actual.AdditionalConfig, "Not expecting the additional settings to be null");
 
-            AnalysisSetting actualSetting = actual.AdditionalSettings.FirstOrDefault(s => string.Equals(settingId, s.Id, StringComparison.InvariantCultureIgnoreCase));
+            ConfigSetting actualSetting = actual.AdditionalConfig.FirstOrDefault(s => string.Equals(settingId, s.Id, StringComparison.InvariantCultureIgnoreCase));
             Assert.IsNotNull(actualSetting, "Expected setting not found: {0}", settingId);
             Assert.AreEqual(expectedValue, actualSetting.Value, "Setting does not have the expected value. SettingId: {0}", settingId);
         }

--- a/Tests/SonarQube.Common.UnitTests/ProcessRunnerTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/ProcessRunnerTests.cs
@@ -70,7 +70,7 @@ xxx yyy
         {
             // Arrange
             string exeName = TestUtils.WriteBatchFileForTest(TestContext,
-@"TIMEOUT 1
+@"TIMEOUT 2
 @echo Hello world
 ");
 

--- a/Tests/SonarQube.Common.UnitTests/SonarQube.Common.UnitTests.csproj
+++ b/Tests/SonarQube.Common.UnitTests/SonarQube.Common.UnitTests.csproj
@@ -54,6 +54,7 @@
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
     <Compile Include="AggregatePropertiesProviderTests.cs" />
+    <Compile Include="AnalysisConfigExtensionsTests.cs" />
     <Compile Include="CmdLineArgsPropertiesProviderTests.cs" />
     <Compile Include="CommandLineParserTests.cs" />
     <Compile Include="ConsoleLoggerTests.cs" />

--- a/Tests/SonarQube.Common.UnitTests/VerbosityCalculatorTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/VerbosityCalculatorTests.cs
@@ -17,52 +17,7 @@ namespace SonarQube.Common.UnitTests
         #region Tests
 
         [TestMethod]
-        public void FromAnalysisConfig_Verbose()
-        {
-            // Arrange
-            AnalysisConfig config = new AnalysisConfig();
-            config.AdditionalSettings = new List<AnalysisSetting>();
-            config.AdditionalSettings.Add(new AnalysisSetting() { Id = SonarProperties.Verbose, Value = "true", Inherited = false });
-            config.AdditionalSettings.Add(new AnalysisSetting() { Id = SonarProperties.LogLevel, Value = "INFO", Inherited = false });
-
-            // Act
-            var verbosity = VerbosityCalculator.ComputeVerbosity(config, new TestLogger());
-
-            // Assert
-            Assert.AreEqual(LoggerVerbosity.Debug, verbosity);
-        }
-
-        [TestMethod]
-        public void FromAnalysisConfig_LogLevel()
-        {
-            // Arrange
-            AnalysisConfig config = new AnalysisConfig();
-            config.AdditionalSettings = new List<AnalysisSetting>();
-            config.AdditionalSettings.Add(new AnalysisSetting() { Id = SonarProperties.LogLevel, Value = "DEBUG|INFO", Inherited = false });
-
-            // Act
-            var verbosity = VerbosityCalculator.ComputeVerbosity(config, new TestLogger());
-
-            // Assert
-            Assert.AreEqual(LoggerVerbosity.Debug, verbosity);
-        }
-
-        [TestMethod]
-        public void FromAnalysisConfig_NoSetting()
-        {
-            // Arrange
-            AnalysisConfig config = new AnalysisConfig();
-            config.AdditionalSettings = new List<AnalysisSetting>();
-
-            // Act
-            var verbosity = VerbosityCalculator.ComputeVerbosity(config, new TestLogger());
-
-            // Assert
-            Assert.AreEqual(LoggerVerbosity.Info, verbosity);
-        }
-
-        [TestMethod]
-        [Description("Looks at how verbosity is computed when various combinations of <<verbose>> and <<log.level>> values are passed in. <<verbose>> takes precendence over <<log.level>>")]
+        [Description("Looks at how verbosity is computed when various combinations of <<verbose>> and <<log.level>> values are passed in. <<verbose>> takes precedence over <<log.level>>")]
         public void FromAnalysisProvider_Precedence()
         {
             CheckVerbosity("Default verbosity does not match", VerbosityCalculator.DefaultLoggingVerbosity);

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
@@ -496,7 +496,9 @@ End Class");
 
             // Create a config file in the config folder containing a reg ex to identify tests projects
             AnalysisConfig config = new AnalysisConfig();
-            config.SetExplicitValue(IsTestFileByName.TestRegExSettingId, ".testp.");
+            config.LocalSettings = new AnalysisProperties();
+            config.LocalSettings.Add(new Property() { Id = IsTestFileByName.TestRegExSettingId, Value = ".testp." });
+
             string configFullPath = Path.Combine(rootInputFolder, FileConstants.ConfigFileName);
             config.Save(configFullPath);
 

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
@@ -776,7 +776,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             AnalysisConfig config = new AnalysisConfig();
             if (regExExpression != null)
             {
-                config.SetExplicitValue(IsTestFileByName.TestRegExSettingId, regExExpression);
+                config.LocalSettings = new AnalysisProperties();
+                config.LocalSettings.Add(new Property() { Id = IsTestFileByName.TestRegExSettingId, Value = regExExpression });
             }
 
             string fullPath = Path.Combine(parentDir, FileConstants.ConfigFileName);
@@ -866,7 +867,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
         private void AssertSettingExists(ProjectInfo projectInfo, string expectedId, string expectedValue)
         {
-            AnalysisSetting actualSetting;
+            ConfigSetting actualSetting;
             bool found = projectInfo.TryGetAnalysisSetting(expectedId, out actualSetting);
             Assert.IsTrue(found, "Expecting the analysis setting to be found. Id: {0}", expectedId);
 

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
@@ -867,7 +867,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
         private void AssertSettingExists(ProjectInfo projectInfo, string expectedId, string expectedValue)
         {
-            ConfigSetting actualSetting;
+            Property actualSetting;
             bool found = projectInfo.TryGetAnalysisSetting(expectedId, out actualSetting);
             Assert.IsTrue(found, "Expecting the analysis setting to be found. Id: {0}", expectedId);
 

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/IsTestFileByNameTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/IsTestFileByNameTests.cs
@@ -216,7 +216,8 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             AnalysisConfig config = new AnalysisConfig();
             if (regExExpression != null)
             {
-                config.SetExplicitValue(IsTestFileByName.TestRegExSettingId, regExExpression);
+                config.LocalSettings = new AnalysisProperties();
+                config.LocalSettings.Add(new Property() { Id = IsTestFileByName.TestRegExSettingId, Value = regExExpression });
             }
 
             string fullPath = Path.Combine(parentDir, FileConstants.ConfigFileName);

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
@@ -312,7 +312,7 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             Assert.IsNotNull(actual, "Supplied project info should not be null");
             Assert.IsNotNull(actual.AnalysisSettings, "AnalysisSettings should not be null");
 
-            AnalysisSetting setting = actual.AnalysisSettings.FirstOrDefault(ar => expectedId.Equals(ar.Id, StringComparison.InvariantCulture));
+            ConfigSetting setting = actual.AnalysisSettings.FirstOrDefault(ar => expectedId.Equals(ar.Id, StringComparison.InvariantCulture));
             Assert.IsNotNull(setting, "AnalysisSetting with the expected id does not exist. Id: {0}", expectedId);
 
             Assert.AreEqual(expectedValue, setting.Value, "Setting does not have the expected value");

--- a/Tests/SonarQube.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
@@ -167,7 +167,7 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             buildEngine.AssertSingleWarningExists(".invalid.non.alpha.first.character");
 
             AssertAnalysisSettingExists(createdProjectInfo, "valid.setting.1", @"c:\dir1\dir2\file.txt");
-            AssertAnalysisSettingExists(createdProjectInfo, "valid.value.is.whitespace.only", " ");
+            AssertAnalysisSettingExists(createdProjectInfo, "valid.value.is.whitespace.only", null);
             AssertAnalysisSettingExists(createdProjectInfo, "valid.value.has.whitespace", "valid setting with whitespace");
             AssertAnalysisSettingExists(createdProjectInfo, "valid.metadata.name.is.case.insensitive", "uppercase metadata name");
             AssertAnalysisSettingExists(createdProjectInfo, "X", "single character key");
@@ -312,7 +312,7 @@ namespace SonarQube.MSBuild.Tasks.UnitTests
             Assert.IsNotNull(actual, "Supplied project info should not be null");
             Assert.IsNotNull(actual.AnalysisSettings, "AnalysisSettings should not be null");
 
-            ConfigSetting setting = actual.AnalysisSettings.FirstOrDefault(ar => expectedId.Equals(ar.Id, StringComparison.InvariantCulture));
+            Property setting = actual.AnalysisSettings.FirstOrDefault(ar => expectedId.Equals(ar.Id, StringComparison.InvariantCulture));
             Assert.IsNotNull(setting, "AnalysisSetting with the expected id does not exist. Id: {0}", expectedId);
 
             Assert.AreEqual(expectedValue, setting.Value, "Setting does not have the expected value");

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/PreProcessorTests.cs
@@ -105,9 +105,9 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             Assert.AreEqual("name", actualConfig.SonarProjectName, "Unexpected project name");
             Assert.AreEqual("1.0", actualConfig.SonarProjectVersion, "Unexpected project version");
 
-            AssertExpectedAnalysisSetting(SonarProperties.HostUrl, "http://host", actualConfig);
-            AssertExpectedAnalysisSetting("cmd.line1", "cmdline.value.1", actualConfig);
-            AssertExpectedAnalysisSetting("server.key", "server value 1", actualConfig);
+            AssertExpectedLocalSetting(SonarProperties.HostUrl, "http://host", actualConfig);
+            AssertExpectedLocalSetting("cmd.line1", "cmdline.value.1", actualConfig);
+            AssertExpectedServerSetting("server.key", "server value 1", actualConfig);
         }
 
         #endregion Tests
@@ -120,13 +120,22 @@ namespace SonarQube.TeamBuild.PreProcessor.Tests
             this.TestContext.AddResultFile(filePath);
         }
 
-        private static void AssertExpectedAnalysisSetting(string key, string expectedValue, AnalysisConfig actualConfig)
+        private static void AssertExpectedLocalSetting(string key, string expectedValue, AnalysisConfig actualConfig)
         {
-            AnalysisSetting setting;
-            actualConfig.TryGetSetting(key, out setting);
+            Property actualProperty;
+            bool found = Property.TryGetProperty(key, actualConfig.LocalSettings, out actualProperty);
 
-            Assert.IsNotNull(setting, "Failed to retrieve the expected setting. Key: {0}", key);
-            Assert.AreEqual(expectedValue, setting.Value, "Unexpected setting value. Key: {0}", key);
+            Assert.IsTrue(found, "Failed to find the expected local setting: {0}", key);
+            Assert.AreEqual(expectedValue, actualProperty.Value, "Unexpected property value. Key: {0}", key);
+        }
+
+        private static void AssertExpectedServerSetting(string key, string expectedValue, AnalysisConfig actualConfig)
+        {
+            Property actualProperty;
+            bool found = Property.TryGetProperty(key, actualConfig.ServerSettings, out actualProperty);
+
+            Assert.IsTrue(found, "Failed to find the expected server setting: {0}", key);
+            Assert.AreEqual(expectedValue, actualProperty.Value, "Unexpected property value. Key: {0}", key);
         }
 
         private static void AssertDirectoryExists(string path)

--- a/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -242,11 +242,15 @@ namespace SonarRunner.Shim.Tests
 
             CreateProjectWithFiles("project1", analysisRootDir);
             AnalysisConfig config = CreateValidConfig(analysisRootDir);
-            
+
             // Add additional properties
-            config.SetExplicitValue("key1", "value1");
-            config.SetExplicitValue("key.2", "value two");
-            config.SetExplicitValue("key.3", " ");
+            config.LocalSettings = new AnalysisProperties();
+            config.LocalSettings.Add(new Property() { Id = "key1", Value = "value1" });
+            config.LocalSettings.Add(new Property() { Id = "key.2", Value = "value two" });
+            config.LocalSettings.Add(new Property() { Id = "key.3", Value = " " });
+
+            config.ServerSettings = new AnalysisProperties();
+            config.ServerSettings.Add(new Property() { Id = "server.key", Value = "should not be added" });
 
             // Act
             ProjectInfoAnalysisResult result = PropertiesFileGenerator.GenerateFile(config, logger);
@@ -261,6 +265,8 @@ namespace SonarRunner.Shim.Tests
             AssertExpectedConfigSetting("key1", "value1", provider);
             AssertExpectedConfigSetting("key.2", "value two", provider);
             AssertExpectedConfigSetting("key.3", " ", provider);
+
+            AssertSettingDoesNotExist("server.key", provider);
         }
 
         #endregion
@@ -326,6 +332,12 @@ namespace SonarRunner.Shim.Tests
         {
             string actualValue = provider.GetProperty(key);
             Assert.AreEqual(expectedValue, actualValue, "Property does not have the expected value. Key: {0}", key);
+        }
+
+        private static void AssertSettingDoesNotExist(string key, SQPropertiesFileReader provider)
+        {
+            string value = provider.GetProperty(key, null);
+            Assert.IsNull(value, "Unexpected value for property. Key: {0}", key);
         }
 
         #endregion

--- a/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -212,8 +212,7 @@ namespace SonarRunner.Shim.Tests
                 SonarProjectKey = "my_project_key",
                 SonarProjectName = "my_project_name",
                 SonarProjectVersion = "1.0",
-                SonarOutputDir = testDir,
-                AdditionalSettings = new List<AnalysisSetting>()
+                SonarOutputDir = testDir
             };
 
             // Act
@@ -377,8 +376,7 @@ namespace SonarRunner.Shim.Tests
                 SonarProjectKey = dummyProjectKey,
                 SonarProjectName = dummyProjectKey,
                 SonarConfigDir = Path.Combine(outputDir, "config"),
-                SonarProjectVersion = "1.0",
-                AdditionalSettings = new List<AnalysisSetting>()
+                SonarProjectVersion = "1.0"
             };
 
             return config;

--- a/Tests/SonarRunner.Shim.Tests/PropertiesWriterTest.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesWriterTest.cs
@@ -276,10 +276,10 @@ sonar.modules=9507E2E6-7342-4A04-9CB9-B0C47C937019
             };
 
             // These are the settings we are going to check. The other config values are not checked.
-            product.AnalysisSettings = new List<AnalysisSetting>();
-            product.AnalysisSettings.Add(new AnalysisSetting() { Id = "my.setting1", Value = "setting1" });
-            product.AnalysisSettings.Add(new AnalysisSetting() { Id = "my.setting2", Value = "setting 2 with spaces" });
-            product.AnalysisSettings.Add(new AnalysisSetting() { Id = "my.setting.3", Value = @"c:\dir1\dir2\foo.txt" }); // path that will be escaped
+            product.AnalysisSettings = new List<ConfigSetting>();
+            product.AnalysisSettings.Add(new ConfigSetting() { Id = "my.setting1", Value = "setting1" });
+            product.AnalysisSettings.Add(new ConfigSetting() { Id = "my.setting2", Value = "setting 2 with spaces" });
+            product.AnalysisSettings.Add(new ConfigSetting() { Id = "my.setting.3", Value = @"c:\dir1\dir2\foo.txt" }); // path that will be escaped
             
             // Act
             PropertiesWriter writer = new PropertiesWriter(config);

--- a/Tests/SonarRunner.Shim.Tests/PropertiesWriterTest.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesWriterTest.cs
@@ -275,11 +275,11 @@ sonar.modules=9507E2E6-7342-4A04-9CB9-B0C47C937019
                 SonarOutputDir = @"C:\my_folder"
             };
 
-            // These are the settings we are going to check. The other config values are not checked.
-            product.AnalysisSettings = new List<ConfigSetting>();
-            product.AnalysisSettings.Add(new ConfigSetting() { Id = "my.setting1", Value = "setting1" });
-            product.AnalysisSettings.Add(new ConfigSetting() { Id = "my.setting2", Value = "setting 2 with spaces" });
-            product.AnalysisSettings.Add(new ConfigSetting() { Id = "my.setting.3", Value = @"c:\dir1\dir2\foo.txt" }); // path that will be escaped
+            // These are the settings we are going to check. The other analysis values are not checked.
+            product.AnalysisSettings = new AnalysisProperties();
+            product.AnalysisSettings.Add(new Property() { Id = "my.setting1", Value = "setting1" });
+            product.AnalysisSettings.Add(new Property() { Id = "my.setting2", Value = "setting 2 with spaces" });
+            product.AnalysisSettings.Add(new Property() { Id = "my.setting.3", Value = @"c:\dir1\dir2\foo.txt" }); // path that will be escaped
             
             // Act
             PropertiesWriter writer = new PropertiesWriter(config);

--- a/Tests/SonarRunner.Shim.Tests/PropertiesWriterTest.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesWriterTest.cs
@@ -307,12 +307,10 @@ sonar.modules=9507E2E6-7342-4A04-9CB9-B0C47C937019
                 SonarOutputDir = @"C:\my_folder"
             };
 
-            IList<AnalysisSetting> globalSettings = new List<AnalysisSetting>();
-
-            globalSettings.Add(new AnalysisSetting() { Id = "my.setting1", Value = "setting1", Inherited = false });
-            globalSettings.Add(new AnalysisSetting() { Id = "my.setting2", Value = "setting 2 with spaces", Inherited = false });
-            globalSettings.Add(new AnalysisSetting() { Id = "my.setting.3", Value = @"c:\dir1\dir2\foo.txt", Inherited = false }); // path that will be escaped
-            globalSettings.Add(new AnalysisSetting() { Id = "my.setting.4", Value = "not to be written out", Inherited = true });
+            AnalysisProperties globalSettings = new AnalysisProperties();
+            globalSettings.Add(new Property() { Id = "my.setting1", Value = "setting1" });
+            globalSettings.Add(new Property() { Id = "my.setting2", Value = "setting 2 with spaces" });
+            globalSettings.Add(new Property() { Id = "my.setting.3", Value = @"c:\dir1\dir2\foo.txt" }); // path that will be escaped
 
             // Act
             PropertiesWriter writer = new PropertiesWriter(config);
@@ -325,7 +323,6 @@ sonar.modules=9507E2E6-7342-4A04-9CB9-B0C47C937019
             AssertSettingExists(propertyReader, "my.setting1", "setting1");
             AssertSettingExists(propertyReader, "my.setting2", "setting 2 with spaces");
             AssertSettingExists(propertyReader, "my.setting.3", @"c:\\dir1\\dir2\\foo.txt");
-            AssertSettingDoesNotExists(propertyReader, "my.setting.4");
         }
 
         #endregion

--- a/Tests/TestUtilities/SQPropertiesFileReader.cs
+++ b/Tests/TestUtilities/SQPropertiesFileReader.cs
@@ -89,7 +89,7 @@ namespace TestUtilities
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(fullPath), "fullPath should be specified");
 
-            this.properties = new Dictionary<string, string>(AnalysisSetting.SettingKeyComparer);
+            this.properties = new Dictionary<string, string>(ConfigSetting.SettingKeyComparer);
             string allText = File.ReadAllText(fullPath);
 
             foreach (Match match in Regex.Matches(allText, KeyValueSettingPattern, RegexOptions.Multiline))


### PR DESCRIPTION
This change separates out the properties which should be passed to the sonar-runner from other configuration settings.
sonar-runner settings are now only stored in AnalysisProperties. Other configuration settings (such as TFS Uri / Build Uri) are stored in ConfigSetting