### PR TITLE
[SONARMSBRU-127] Fixed error in passing args to sonar-runner

### DIFF
--- a/SonarQube.Common/ProcessRunnerArguments.cs
+++ b/SonarQube.Common/ProcessRunnerArguments.cs
@@ -120,11 +120,7 @@ namespace SonarQube.Common
             return SensitivePropertyKeys.Any(marker => text.IndexOf(marker, StringComparison.OrdinalIgnoreCase) > -1);
         }
 
-        #endregion
-
-        #region Private methods
-
-        private static string GetQuotedArg(string arg)
+        public static string GetQuotedArg(string arg)
         {
             Debug.Assert(arg != null, "Not expecting an argument to be null");
 

--- a/SonarQube.TeamBuild.PostProcessor/Program.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Program.cs
@@ -27,9 +27,18 @@ namespace SonarQube.TeamBuild.PostProcessor
 
             AnalysisConfig config = GetAnalysisConfig(settings, logger);
 
-            MSBuildPostProcessor postProcessor = new MSBuildPostProcessor(new CoverageReportProcessor(), new SonarRunnerWrapper(), new SummaryReportBuilder());
+            bool succeeded;
+            if (config == null)
+            {
+                succeeded = false;
+            }
+            else
+            {
+                MSBuildPostProcessor postProcessor = new MSBuildPostProcessor(new CoverageReportProcessor(), new SonarRunnerWrapper(), new SummaryReportBuilder());
 
-            bool succeeded = postProcessor.Execute(args, config, settings, logger);
+                succeeded = postProcessor.Execute(args, config, settings, logger);
+            }
+
             return succeeded ? SuccessCode : ErrorCode;
         }
 

--- a/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
@@ -93,15 +93,6 @@ namespace SonarQube.TeamBuild.PostProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarQube post-processing cannot be performed - required settings are missing.
-        /// </summary>
-        internal static string ERROR_MissingSettings {
-            get {
-                return ResourceManager.GetString("ERROR_MissingSettings", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Loading the SonarQube analysis config from {0}.
         /// </summary>
         internal static string MSG_LoadingConfig {

--- a/SonarQube.TeamBuild.PostProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.resx
@@ -131,9 +131,6 @@ Please delete the analysis config file and try the build again.</value>
     <value>SonarQube analysis could not be completed because the analysis configuration file could not be found.
 Expected location: {0}</value>
   </data>
-  <data name="ERROR_MissingSettings" xml:space="preserve">
-    <value>SonarQube post-processing cannot be performed - required settings are missing</value>
-  </data>
   <data name="MSG_LoadingConfig" xml:space="preserve">
     <value>Loading the SonarQube analysis config from {0}</value>
   </data>

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -21,26 +21,6 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
         #region Tests
 
         [TestMethod]
-        public void PostProc_CannotFindConfig()
-        {
-            // Arrange
-            PostProcTestContext context = new PostProcTestContext(this.TestContext);
-            context.Config = null;
-
-            // Act
-            bool success = Execute(context);
-
-            // Assert
-            Assert.IsFalse(success, "Not expecting post-processor to have succeeded");
-
-            context.CodeCoverage.AssertNotExecuted();
-            context.Runner.AssertNotExecuted();
-            context.ReportBuilder.AssertNotExecuted();
-
-            context.Logger.AssertErrorsLogged(1);
-        }
-
-        [TestMethod]
         public void PostProc_ExecutionFailsIfCodeCoverageFails()
         {
             // Arrange
@@ -138,8 +118,16 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             {
                 "/d:sonar.jdbc.password=dbpwd",
                 "/d:sonar.jdbc.username=dbuser",
-                "/d:sonar.password=pwd",
+                "/d:sonar.password=\"my pwd\"",
                 "/d:sonar.login=login"
+            };
+
+            string[] expectedArgs = new string[]
+            {
+                "-Dsonar.jdbc.password=dbpwd",
+                "-Dsonar.jdbc.username=dbuser",
+                "-Dsonar.password=\"my pwd\"",
+                "-Dsonar.login=login"
             };
 
             // Act
@@ -152,7 +140,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             context.Runner.AssertExecuted();
             context.ReportBuilder.AssertExecuted();
 
-            CollectionAssert.AreEqual(suppliedArgs, context.Runner.SuppliedCommandLineArgs.ToArray(), "Unexpected command line args passed to the sonar-runner");
+            CollectionAssert.AreEqual(expectedArgs, context.Runner.SuppliedCommandLineArgs.ToArray(), "Unexpected command line args passed to the sonar-runner");
 
             context.Logger.AssertErrorsLogged(0);
         }


### PR DESCRIPTION
The post-processor wasn't reformatting the args from e.g "/d:x=y" to "-Dx=y"