### PR TITLE
SONARMSBRU-118: Better error message for certificate problems

### DIFF
--- a/SonarQube.Common/Resources.Designer.cs
+++ b/SonarQube.Common/Resources.Designer.cs
@@ -224,6 +224,15 @@ namespace SonarQube.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A server certificate could not be validated. Possible cause: you are using a self signed SSL certificate but you haven&apos;t installed it on the client machine. Please make sure the you can access {0} without encountering certificate errors..
+        /// </summary>
+        public static string ERROR_TrustFailure {
+            get {
+                return ResourceManager.GetString("ERROR_TrustFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name of the SonarQube server could not be resolved. Check the url is correct and that the server is available. Url: {0}.
         /// </summary>
         public static string ERROR_UrlNameResolutionFailed {

--- a/SonarQube.Common/Resources.resx
+++ b/SonarQube.Common/Resources.resx
@@ -239,4 +239,7 @@
   <data name="ERROR_FileNotFound" xml:space="preserve">
     <value>Could not find a file on the SonarQube server. Url: {0}</value>
   </data>
+  <data name="ERROR_TrustFailure" xml:space="preserve">
+    <value>A server certificate could not be validated. Possible cause: you are using a self signed SSL certificate but you haven't installed it on the client machine. Please make sure the you can access {0} without encountering certificate errors.</value>
+  </data>
 </root>

--- a/SonarQube.Common/Utilities.cs
+++ b/SonarQube.Common/Utilities.cs
@@ -171,6 +171,12 @@ namespace SonarQube.Common
                 return true;
             }
 
+            if (ex.Status == WebExceptionStatus.TrustFailure)
+            {
+                logger.LogError(Resources.ERROR_TrustFailure, hostUrl);
+                return true;
+            }
+
             return false;
         }
         #endregion


### PR DESCRIPTION
I've setup SSL as described here: http://docs.sonarqube.org/display/SONAR/Running+SonarQube+Over+HTTPS

I can now access the my SQ server over HTTPS but by default the connection is not safe (you'll get a cert error in the browser - please use IE). Also the bug now repros.

Next I tried to install the certificate in several ways but was ultimately unable to get my browser / client machine to accept the connection. It may have to do with our intranet settings. So I am unable to provide a better suggestion / KB article on what has to be done to install the client certificate. 