### PR TITLE
[SONARMSBRU-127] Amended properties generator to not write sensitive …

### DIFF
--- a/SonarQube.Common/AnalysisProperties/Property.cs
+++ b/SonarQube.Common/AnalysisProperties/Property.cs
@@ -36,8 +36,20 @@ namespace SonarQube.Common
 
         #endregion
 
+        #region Public methods
+
+        /// <summary>
+        /// Returns whether the property contains any sensitive data
+        /// </summary>
+        public bool ContainsSensitiveData()
+        {
+            return ProcessRunnerArguments.ContainsSensitiveData(this.Id) || ProcessRunnerArguments.ContainsSensitiveData(this.Value);
+        }
+
+        #endregion
+
         #region Static helper methods
-        
+
         //TODO: this expression only works for single-line values
         // Regular expression pattern: we're looking for matches that:
         // * start at the beginning of a line

--- a/SonarQube.Common/ProcessRunnerArguments.cs
+++ b/SonarQube.Common/ProcessRunnerArguments.cs
@@ -117,6 +117,12 @@ namespace SonarQube.Common
         public static bool ContainsSensitiveData(string text)
         {
             Debug.Assert(SensitivePropertyKeys != null, "SensitiveDataMarkers array should not be null");
+
+            if (text == null)
+            {
+                return false;
+            }
+
             return SensitivePropertyKeys.Any(marker => text.IndexOf(marker, StringComparison.OrdinalIgnoreCase) > -1);
         }
 

--- a/SonarQube.TeamBuild.PreProcessor/AnalysisConfigGenerator.cs
+++ b/SonarQube.TeamBuild.PreProcessor/AnalysisConfigGenerator.cs
@@ -67,7 +67,10 @@ namespace SonarQube.TeamBuild.PreProcessor
         
         private static void AddSetting(AnalysisProperties properties, string id, string value)
         {
-            if (!ProcessRunnerArguments.ContainsSensitiveData(id) && !ProcessRunnerArguments.ContainsSensitiveData(value))
+            Property property = new Property() { Id = id, Value = value };
+
+            // Ensure it isn't possible to write sensitive data to the config file
+            if (!property.ContainsSensitiveData())
             {
                 properties.Add(new Property() { Id = id, Value = value });
             }

--- a/SonarQube.TeamBuild.PreProcessor/ProcessedArgs.cs
+++ b/SonarQube.TeamBuild.PreProcessor/ProcessedArgs.cs
@@ -8,7 +8,6 @@
 using SonarQube.Common;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SonarQube.TeamBuild.PreProcessor
 {

--- a/SonarRunner.Shim/PropertiesWriter.cs
+++ b/SonarRunner.Shim/PropertiesWriter.cs
@@ -200,6 +200,9 @@ namespace SonarRunner.Shim
 
         private static void AppendKeyValue(StringBuilder sb, string key, string value)
         {
+            Debug.Assert(!ProcessRunnerArguments.ContainsSensitiveData(key) && !ProcessRunnerArguments.ContainsSensitiveData(value),
+                "Not expecting sensitive data to be written to the sonar-project properties file. Key: {0}", key);
+
             sb.Append(key);
             sb.Append('=');
             sb.AppendLine(Escape(value));

--- a/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarRunner.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -248,6 +248,11 @@ namespace SonarRunner.Shim.Tests
             config.LocalSettings.Add(new Property() { Id = "key.2", Value = "value two" });
             config.LocalSettings.Add(new Property() { Id = "key.3", Value = " " });
 
+            // Sensitive data should not be written
+            config.LocalSettings.Add(new Property() { Id = SonarProperties.DbPassword, Value ="secret db pwd" });
+            config.LocalSettings.Add(new Property() { Id = SonarProperties.SonarPassword, Value = "secret pwd" });
+
+            // Server properties should not be added
             config.ServerSettings = new AnalysisProperties();
             config.ServerSettings.Add(new Property() { Id = "server.key", Value = "should not be added" });
 
@@ -266,6 +271,8 @@ namespace SonarRunner.Shim.Tests
             provider.AssertSettingExists("key.3", " ");
 
             provider.AssertSettingDoesNotExist("server.key");
+            provider.AssertSettingDoesNotExist(SonarProperties.DbPassword);
+            provider.AssertSettingDoesNotExist(SonarProperties.SonarPassword);
         }
 
         [TestMethod] // Old VS Bootstrapper should be forceably disabled: https://jira.sonarsource.com/browse/SONARMSBRU-122


### PR DESCRIPTION
…data

Manual testing of the end-to-end changes found an issue with how sensitive values are passed: if the user supplies sensitive settings in a file in the "begin" phase, those settings are stripped out from the analysis config file and so are not available in the "end" phase. This breaks the simple upgrade path from v1.0.
The fix is as follows: if the user supplies a settings file, we shouldn't copy the data out of it into the AnalysisConfig file. Instead, we should pass the location of the supplied file in the AnalysisConfig and re-load it when necessary. Any sensitive data in the supplied settings file should be passed to the sonar-runner on the command line, rather than written to sonar-project.properties file.

This changeset is a small, self-contained part of the overall fix. It checks that sensitive data is not written to the sonar-project.properties file.