### PR TITLE
SONARMSBRU-130 - Do not crash and do not stop the analysis if VS is not installed on the machine

### DIFF
--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -49,7 +49,7 @@ namespace SonarQube.TeamBuild.Integration
 
             if (this.conversionToolPath == null)
             {
-                logger.LogError(Resources.CONV_ERROR_FailToFindConversionTool);
+                logger.LogError(Resources.CONV_WARN_FailToFindConversionTool);
                 success = false;
             }
             else

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -49,7 +49,7 @@ namespace SonarQube.TeamBuild.Integration
 
             if (this.conversionToolPath == null)
             {
-                logger.LogError(Resources.CONV_WARN_FailToFindConversionTool);
+                logger.LogWarning(Resources.CONV_WARN_FailToFindConversionTool);
                 success = false;
             }
             else

--- a/SonarQube.TeamBuild.Integration/CoverageReportProcessorBase.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportProcessorBase.cs
@@ -60,8 +60,12 @@ namespace SonarQube.TeamBuild.Integration
 
         public bool ProcessCoverageReports()
         {
-            Debug.Assert(this.config != null, "Call initialise first");
-            Debug.Assert(this.succesfullyInitialised, "Initialisation failed, cannot process coverage reports");
+            if (!this.succesfullyInitialised)
+            {
+                throw new InvalidOperationException(Resources.EX_CoverageReportProcessorNotInitialised);
+            }
+
+            Debug.Assert(this.config != null, "Expecting the config to not be null. Did you call Initialise() ?");
 
             // Fetch all of the report URLs
             this.logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);

--- a/SonarQube.TeamBuild.Integration/CoverageReportProcessorBase.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportProcessorBase.cs
@@ -15,8 +15,13 @@ namespace SonarQube.TeamBuild.Integration
     public abstract class CoverageReportProcessorBase : ICoverageReportProcessor
     {
         private const string XmlReportFileExtension = "coveragexml";
+        private readonly ICoverageReportConverter converter;
 
-        private ICoverageReportConverter converter;
+        private AnalysisConfig config;
+        private TeamBuildSettings settings;
+        private ILogger logger;
+        
+        private bool succesfullyInitialised = false;
 
         protected CoverageReportProcessorBase(ICoverageReportConverter converter)
         {
@@ -29,36 +34,47 @@ namespace SonarQube.TeamBuild.Integration
 
         #region ICoverageReportProcessor interface
 
-        public bool ProcessCoverageReports(AnalysisConfig context, TeamBuildSettings settings, ILogger logger)
+
+        public bool Initialise(AnalysisConfig config, TeamBuildSettings settings, ILogger logger)
         {
-            if (context == null)
+            if (config == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException("config");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
             }
             if (logger == null)
             {
                 throw new ArgumentNullException("logger");
             }
 
-            if (!this.converter.Initialize(logger))
-            {
-                // If we can't initialize the converter (e.g. we can't find the exe required to do the
-                // conversion) there in there isn't any point in downloading the binary reports
-                return false;
-            }
+            this.config = config;
+            this.settings = settings;
+            this.logger = logger;
+
+            this.succesfullyInitialised =  this.converter.Initialize(logger);
+            return succesfullyInitialised;
+        }
+
+        public bool ProcessCoverageReports()
+        {
+            Debug.Assert(this.config != null, "Call initialise first");
+            Debug.Assert(this.succesfullyInitialised, "Initialisation failed, cannot process coverage reports");
 
             // Fetch all of the report URLs
-            logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);
+            this.logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);
 
             string binaryFilePath;
-            bool continueProcessing = this.TryGetBinaryReportFile(context, settings, logger, out binaryFilePath);
+            bool success = this.TryGetBinaryReportFile(this.config, this.settings, this.logger, out binaryFilePath);
 
-            if (continueProcessing && binaryFilePath != null)
+            if (success && binaryFilePath != null)
             {
-                continueProcessing = ProcessBinaryCodeCoverageReport(binaryFilePath, context, this.converter, logger);
+                success = this.ProcessBinaryCodeCoverageReport(binaryFilePath);
             }
 
-            return continueProcessing;
+            return success;
         }
 
         protected abstract bool TryGetBinaryReportFile(AnalysisConfig config, TeamBuildSettings settings, ILogger logger, out string binaryFilePath);
@@ -67,18 +83,18 @@ namespace SonarQube.TeamBuild.Integration
 
         #region Private methods
 
-        private static bool ProcessBinaryCodeCoverageReport(string binaryCoverageFilePath, AnalysisConfig context, ICoverageReportConverter converter, ILogger logger)
+        private bool ProcessBinaryCodeCoverageReport(string binaryCoverageFilePath)
         {
             bool success = false;
             string xmlFileName = Path.ChangeExtension(binaryCoverageFilePath, XmlReportFileExtension);
 
             Debug.Assert(!File.Exists(xmlFileName), "Not expecting a file with the name of the binary-to-XML conversion output to already exist: " + xmlFileName);
-            success = converter.ConvertToXml(binaryCoverageFilePath, xmlFileName, logger);
+            success = converter.ConvertToXml(binaryCoverageFilePath, xmlFileName, this.logger);
 
             if (success)
             {
                 logger.LogDebug(Resources.PROC_DIAG_UpdatingProjectInfoFiles);
-                InsertCoverageAnalysisResults(context.SonarOutputDir, xmlFileName);
+                InsertCoverageAnalysisResults(this.config.SonarOutputDir, xmlFileName);
             }
 
             return success;
@@ -103,6 +119,7 @@ namespace SonarQube.TeamBuild.Integration
                 }
             }
         }
+
 
         #endregion
 

--- a/SonarQube.TeamBuild.Integration/Interfaces/ICoverageReportProcessor.cs
+++ b/SonarQube.TeamBuild.Integration/Interfaces/ICoverageReportProcessor.cs
@@ -11,6 +11,16 @@ namespace SonarQube.TeamBuild.Integration
 {
     public interface ICoverageReportProcessor
     {
-        bool ProcessCoverageReports(AnalysisConfig context, TeamBuildSettings settings, ILogger logger);
+        /// <summary>
+        /// Initialises the converter
+        /// </summary>
+        /// <returns>Operation success</returns>
+        bool Initialise(AnalysisConfig config, TeamBuildSettings settings, ILogger logger);
+
+        /// <summary>
+        /// Locate, download and convert the code coverage report
+        /// </summary>
+        /// <returns>Operation success</returns>
+        bool ProcessCoverageReports();
     }
 }

--- a/SonarQube.TeamBuild.Integration/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.Integration/Resources.Designer.cs
@@ -98,20 +98,20 @@ namespace SonarQube.TeamBuild.Integration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to locate the code coverage command line tool.
-        /// </summary>
-        internal static string CONV_ERROR_FailToFindConversionTool {
-            get {
-                return ResourceManager.GetString("CONV_ERROR_FailToFindConversionTool", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Failed to convert the binary coverage file to XML. The expected output file was not found: {0}.
         /// </summary>
         internal static string CONV_ERROR_OutputFileNotFound {
             get {
                 return ResourceManager.GetString("CONV_ERROR_OutputFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to locate the code coverage command line tool. Possible cause: Visual Studio is not installed..
+        /// </summary>
+        internal static string CONV_WARN_FailToFindConversionTool {
+            get {
+                return ResourceManager.GetString("CONV_WARN_FailToFindConversionTool", resourceCulture);
             }
         }
         

--- a/SonarQube.TeamBuild.Integration/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.Integration/Resources.Designer.cs
@@ -107,7 +107,7 @@ namespace SonarQube.TeamBuild.Integration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to locate the code coverage command line tool. Possible cause: Visual Studio is not installed..
+        ///   Looks up a localized string similar to Failed to find the code coverage command line tool. Possible cause: Visual Studio is not installed, or the installed version does not support code coverage..
         /// </summary>
         internal static string CONV_WARN_FailToFindConversionTool {
             get {
@@ -130,6 +130,15 @@ namespace SonarQube.TeamBuild.Integration {
         internal static string DOWN_DIAG_DownloadCoverageReportFromTo {
             get {
                 return ResourceManager.GetString("DOWN_DIAG_DownloadCoverageReportFromTo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Coverage Report Processor was not initialised before use..
+        /// </summary>
+        internal static string EX_CoverageReportProcessorNotInitialised {
+            get {
+                return ResourceManager.GetString("EX_CoverageReportProcessorNotInitialised", resourceCulture);
             }
         }
         

--- a/SonarQube.TeamBuild.Integration/Resources.resx
+++ b/SonarQube.TeamBuild.Integration/Resources.resx
@@ -131,11 +131,11 @@
     <value>Failed to convert the downloaded code coverage tool to XML. No code coverage information will be uploaded to SonarQube.
 Check that the downloaded code coverage file ({0}) is valid by opening it in Visual Studio. If it is not, check that the internet security settings on the build machine allow files to be downloaded from the Team Foundation Server machine.</value>
   </data>
-  <data name="CONV_ERROR_FailToFindConversionTool" xml:space="preserve">
-    <value>Failed to locate the code coverage command line tool</value>
-  </data>
   <data name="CONV_ERROR_OutputFileNotFound" xml:space="preserve">
     <value>Failed to convert the binary coverage file to XML. The expected output file was not found: {0}</value>
+  </data>
+  <data name="CONV_WARN_FailToFindConversionTool" xml:space="preserve">
+    <value>Failed to locate the code coverage command line tool. Possible cause: Visual Studio is not installed.</value>
   </data>
   <data name="DOWN_DIAG_ConnectedToTFS" xml:space="preserve">
     <value>Connected to {0}</value>

--- a/SonarQube.TeamBuild.Integration/Resources.resx
+++ b/SonarQube.TeamBuild.Integration/Resources.resx
@@ -135,13 +135,16 @@ Check that the downloaded code coverage file ({0}) is valid by opening it in Vis
     <value>Failed to convert the binary coverage file to XML. The expected output file was not found: {0}</value>
   </data>
   <data name="CONV_WARN_FailToFindConversionTool" xml:space="preserve">
-    <value>Failed to locate the code coverage command line tool. Possible cause: Visual Studio is not installed.</value>
+    <value>Failed to find the code coverage command line tool. Possible cause: Visual Studio is not installed, or the installed version does not support code coverage.</value>
   </data>
   <data name="DOWN_DIAG_ConnectedToTFS" xml:space="preserve">
     <value>Connected to {0}</value>
   </data>
   <data name="DOWN_DIAG_DownloadCoverageReportFromTo" xml:space="preserve">
     <value>Downloading coverage file from {0} to {1}</value>
+  </data>
+  <data name="EX_CoverageReportProcessorNotInitialised" xml:space="preserve">
+    <value>The Coverage Report Processor was not initialised before use.</value>
   </data>
   <data name="PROC_DIAG_FetchingCoverageReportInfoFromServer" xml:space="preserve">
     <value>Fetching code coverage report information from TFS...</value>

--- a/SonarQube.TeamBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/SonarQube.TeamBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -72,9 +72,14 @@ namespace SonarQube.TeamBuild.PostProcessor
                 return false;
             }
 
-            // Handle code coverage reports
-            if (!this.codeCoverageProcessor.ProcessCoverageReports(config, settings, logger))
+            if (!this.codeCoverageProcessor.Initialise(config, settings, logger))
             {
+                // if initialisation fails (e.g. no VS is installed) just log a warning
+                logger.LogWarning(Resources.WARN_CannotProcessCoverage);
+            }
+            else if (!this.codeCoverageProcessor.ProcessCoverageReports())
+            {
+                //  if processing fails, stop the workflow
                 return false;
             }
 

--- a/SonarQube.TeamBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/SonarQube.TeamBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -72,21 +72,17 @@ namespace SonarQube.TeamBuild.PostProcessor
                 return false;
             }
 
-            if (!this.codeCoverageProcessor.Initialise(config, settings, logger))
-            {
-                // if initialisation fails (e.g. no VS is installed) just log a warning
-                logger.LogWarning(Resources.WARN_CannotProcessCoverage);
-            }
-            else if (!this.codeCoverageProcessor.ProcessCoverageReports())
+            // if initialisation fails a warning will have been logged at the source of the failure
+            bool initialised = this.codeCoverageProcessor.Initialise(config, settings, logger);
+
+            if (initialised && !this.codeCoverageProcessor.ProcessCoverageReports())
             {
                 //  if processing fails, stop the workflow
                 return false;
             }
 
             ProjectInfoAnalysisResult result = InvokeSonarRunner(provider, config, logger);
-
             this.reportBuilder.GenerateReports(settings, config, result, logger);
-
             return result.RanToCompletion;
         }
 
@@ -101,12 +97,15 @@ namespace SonarQube.TeamBuild.PostProcessor
                     logger.LogDebug(Resources.SETTINGS_InLegacyTeamBuild);
 
                     break;
+
                 case BuildEnvironment.TeamBuild:
                     logger.LogDebug(Resources.SETTINGS_InTeamBuild);
                     break;
+
                 case BuildEnvironment.NotTeamBuild:
                     logger.LogDebug(Resources.SETTINGS_NotInTeamBuild);
                     break;
+
                 default:
                     break;
             }

--- a/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
@@ -260,7 +260,7 @@ namespace SonarQube.TeamBuild.PostProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot process the code coverage information. Look at previous warnings for details..
+        ///   Looks up a localized string similar to Cannot process the code coverage information. Look at the previous warnings for details..
         /// </summary>
         internal static string WARN_CannotProcessCoverage {
             get {

--- a/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
@@ -258,5 +258,14 @@ namespace SonarQube.TeamBuild.PostProcessor {
                 return ResourceManager.GetString("SETTINGS_NotInTeamBuild", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot process the code coverage information. Look at previous warnings for details..
+        /// </summary>
+        internal static string WARN_CannotProcessCoverage {
+            get {
+                return ResourceManager.GetString("WARN_CannotProcessCoverage", resourceCulture);
+            }
+        }
     }
 }

--- a/SonarQube.TeamBuild.PostProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.resx
@@ -190,4 +190,7 @@ Config directory: {3}
 Output directory: {4}
 Config file: {4}</value>
   </data>
+  <data name="WARN_CannotProcessCoverage" xml:space="preserve">
+    <value>Cannot process the code coverage information. Look at previous warnings for details.</value>
+  </data>
 </root>

--- a/SonarQube.TeamBuild.PostProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.resx
@@ -191,6 +191,6 @@ Output directory: {4}
 Config file: {4}</value>
   </data>
   <data name="WARN_CannotProcessCoverage" xml:space="preserve">
-    <value>Cannot process the code coverage information. Look at previous warnings for details.</value>
+    <value>Cannot process the code coverage information. Look at the previous warnings for details.</value>
   </data>
 </root>

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/TfsLegacyCoverageReportProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/TfsLegacyCoverageReportProcessorTests.cs
@@ -53,12 +53,13 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             // Act
             bool initResult = processor.Initialise(context, settings, logger);
-        
+
             // Assert
+            Assert.IsFalse(initResult, "Expecting false: processor should not have been initialised successfully");
+
             urlProvider.AssertGetUrlsNotCalled();
             downloader.AssertDownloadNotCalled();
             converter.AssertConvertNotCalled();
-            Assert.IsFalse(initResult, "Expecting false: processor was not initialised");
 
             logger.AssertWarningsLogged(0);
             logger.AssertErrorsLogged(0);
@@ -80,13 +81,13 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             // Act
             bool initResult = processor.Initialise(context, settings, logger);
+            Assert.IsTrue(initResult, "Expecting true: processor should have been initialised successfully");
             bool result = processor.ProcessCoverageReports();
 
             // Assert
             urlProvider.AssertGetUrlsCalled();
             downloader.AssertDownloadNotCalled(); // no urls returned, so should go any further
             converter.AssertConvertNotCalled();
-            Assert.IsTrue(initResult, "Expecting true: processor was initialised");
             Assert.IsTrue(result, "Expecting true: no coverage reports is a valid scenario");
 
             logger.AssertWarningsLogged(0);
@@ -110,13 +111,13 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             // Act
             bool initResult = processor.Initialise(context, settings, logger);
+            Assert.IsTrue(initResult, "Expecting true: processor should have been initialised successfully");
             bool result = processor.ProcessCoverageReports();
 
             // Assert
             urlProvider.AssertGetUrlsCalled();
             downloader.AssertDownloadNotCalled(); // Multiple urls so should early out
             converter.AssertConvertNotCalled();
-            Assert.IsTrue(initResult, "Expecting true: processor was initialised");
             Assert.IsFalse(result, "Expecting false: can't process multiple coverage reports");
 
             logger.AssertErrorsLogged(1);
@@ -139,6 +140,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             // Act
             bool initResult = processor.Initialise(context, settings, logger);
+            Assert.IsTrue(initResult, "Expecting true: processor should have been initialised successfully");
             bool result = processor.ProcessCoverageReports();
 
             // Assert
@@ -148,7 +150,6 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             downloader.AssertExpectedUrlsRequested(ValidUrl1);
 
-            Assert.IsTrue(initResult, "Expecting true: processor was initialised");
             Assert.IsFalse(result, "Expecting false: report could not be downloaded");
 
             logger.AssertErrorsLogged(1);
@@ -173,6 +174,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             // Act
             bool initResult = processor.Initialise(context, settings, logger);
+            Assert.IsTrue(initResult, "Expecting true: processor should have been initialised successfully");
             bool result = processor.ProcessCoverageReports();
 
             // Assert
@@ -182,7 +184,6 @@ namespace SonarQube.TeamBuild.Integration.Tests
 
             downloader.AssertExpectedUrlsRequested(ValidUrl2);
             downloader.AssertExpectedTargetFileNamesSupplied(Path.Combine(context.SonarOutputDir, TfsLegacyCoverageReportProcessor.DownloadFileName));
-            Assert.IsTrue(initResult, "Expecting true: processor was initialised");
             Assert.IsTrue(result, "Expecting true: happy path");
 
             logger.AssertWarningsLogged(0);

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/Infrastructure/MockCodeCoverageProcessor.cs
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/Infrastructure/MockCodeCoverageProcessor.cs
@@ -7,41 +7,63 @@
 using SonarQube.TeamBuild.Integration;
 using SonarQube.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace SonarQube.TeamBuild.PostProcessor.Tests
 {
     internal class MockCodeCoverageProcessor : ICoverageReportProcessor
     {
-        private bool methodCalled;
+        private bool processCoverageMethodCalled;
+        private bool initalizedCalled;
 
         #region Test helpers
 
-        public bool ValueToReturn { get; set; }
+        public bool ProcessValueToReturn { get; set; }
+        public bool InitialiseValueToReturn { get; set; }
 
         #endregion
 
         #region ICoverageReportProcessor interface
 
-        public bool ProcessCoverageReports(AnalysisConfig context, TeamBuildSettings settings, ILogger logger)
+        public bool Initialise(AnalysisConfig context, TeamBuildSettings settings, ILogger logger)
         {
-            Assert.IsFalse(this.methodCalled, "Expecting ProcessCoverageReports to be called only once");
-            this.methodCalled = true;
-            return ValueToReturn;
+            Assert.IsFalse(this.initalizedCalled, "Expecting Initialise to be called only once");
+            this.initalizedCalled = true;
+            return InitialiseValueToReturn;
+        }
+
+        public bool ProcessCoverageReports()
+        {
+            Assert.IsFalse(this.processCoverageMethodCalled, "Expecting ProcessCoverageReports to be called only once");
+            Assert.IsTrue(this.initalizedCalled, "Expecting Initialise to be called first");
+            this.processCoverageMethodCalled = true;
+            return ProcessValueToReturn;
         }
 
         #endregion
 
         #region Checks
 
-        public void AssertExecuted()
+        public void AssertExecutedCalled()
         {
-            Assert.IsTrue(this.methodCalled, "Expecting the sonar-runner to have been called");
+            Assert.IsTrue(this.processCoverageMethodCalled, "Expecting the sonar-runner to have been called");
         }
 
-        public void AssertNotExecuted()
+        public void AssertExecutedNotCalled()
         {
-            Assert.IsFalse(this.methodCalled, "Not expecting the sonar-runner to have been called");
+            Assert.IsFalse(this.processCoverageMethodCalled, "Not expecting the sonar-runner to have been called");
         }
+
+        public void AssertInitializedCalled()
+        {
+            Assert.IsTrue(this.initalizedCalled, "Expecting the sonar-runner to have been called");
+        }
+
+        public void AssertInitialisedNotCalled()
+        {
+            Assert.IsFalse(this.initalizedCalled, "Not expecting the sonar-runner to have been called");
+        }
+
 
         #endregion
 

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/Infrastructure/MockCodeCoverageProcessor.cs
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/Infrastructure/MockCodeCoverageProcessor.cs
@@ -14,7 +14,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
     internal class MockCodeCoverageProcessor : ICoverageReportProcessor
     {
         private bool processCoverageMethodCalled;
-        private bool initalizedCalled;
+        private bool initalisedCalled;
 
         #region Test helpers
 
@@ -27,15 +27,15 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
 
         public bool Initialise(AnalysisConfig context, TeamBuildSettings settings, ILogger logger)
         {
-            Assert.IsFalse(this.initalizedCalled, "Expecting Initialise to be called only once");
-            this.initalizedCalled = true;
+            Assert.IsFalse(this.initalisedCalled, "Expecting Initialise to be called only once");
+            this.initalisedCalled = true;
             return InitialiseValueToReturn;
         }
 
         public bool ProcessCoverageReports()
         {
             Assert.IsFalse(this.processCoverageMethodCalled, "Expecting ProcessCoverageReports to be called only once");
-            Assert.IsTrue(this.initalizedCalled, "Expecting Initialise to be called first");
+            Assert.IsTrue(this.initalisedCalled, "Expecting Initialise to be called first");
             this.processCoverageMethodCalled = true;
             return ProcessValueToReturn;
         }
@@ -44,24 +44,24 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
 
         #region Checks
 
-        public void AssertExecutedCalled()
+        public void AssertExecuteCalled()
         {
             Assert.IsTrue(this.processCoverageMethodCalled, "Expecting the sonar-runner to have been called");
         }
 
-        public void AssertExecutedNotCalled()
+        public void AssertExecuteNotCalled()
         {
             Assert.IsFalse(this.processCoverageMethodCalled, "Not expecting the sonar-runner to have been called");
         }
 
         public void AssertInitializedCalled()
         {
-            Assert.IsTrue(this.initalizedCalled, "Expecting the sonar-runner to have been called");
+            Assert.IsTrue(this.initalisedCalled, "Expecting the sonar-runner to have been called");
         }
 
         public void AssertInitialisedNotCalled()
         {
-            Assert.IsFalse(this.initalizedCalled, "Not expecting the sonar-runner to have been called");
+            Assert.IsFalse(this.initalisedCalled, "Not expecting the sonar-runner to have been called");
         }
 
 

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -48,8 +48,6 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
         {
             // Arrange
             PostProcTestContext context = new PostProcTestContext(this.TestContext);
-            context.CodeCoverage.InitialiseValueToReturn = true;
-            context.CodeCoverage.ProcessValueToReturn = true;
             context.Runner.ValueToReturn = new ProjectInfoAnalysisResult();
             context.Runner.ValueToReturn.RanToCompletion = false;
 
@@ -72,8 +70,6 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
         {
             // Arrange
             PostProcTestContext context = new PostProcTestContext(this.TestContext);
-            context.CodeCoverage.ProcessValueToReturn = true;
-            context.CodeCoverage.InitialiseValueToReturn = true;
             context.Runner.ValueToReturn = new ProjectInfoAnalysisResult();
             context.Runner.ValueToReturn.RanToCompletion = true;
 
@@ -149,8 +145,6 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
         {
             // Arrange
             PostProcTestContext context = new PostProcTestContext(this.TestContext);
-            context.CodeCoverage.InitialiseValueToReturn = true;
-            context.CodeCoverage.ProcessValueToReturn = true;
             context.Runner.ValueToReturn = new ProjectInfoAnalysisResult();
             context.Runner.ValueToReturn.RanToCompletion = true;
 
@@ -210,6 +204,9 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
                 this.codeCoverage = new MockCodeCoverageProcessor();
                 this.runner = new MockSonarRunner();
                 this.reportBuilder = new MockSummaryReportBuilder();
+
+                this.codeCoverage.InitialiseValueToReturn = true;
+                this.codeCoverage.ProcessValueToReturn = true;
             }
 
             public AnalysisConfig Config { get; set; }

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -35,7 +35,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             Assert.IsFalse(success, "Not expecting post-processor to have succeeded");
 
             context.CodeCoverage.AssertInitializedCalled();
-            context.CodeCoverage.AssertExecutedCalled();
+            context.CodeCoverage.AssertExecuteCalled();
             context.Runner.AssertNotExecuted();
             context.ReportBuilder.AssertNotExecuted();
 
@@ -57,7 +57,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             // Assert
             Assert.IsFalse(success, "Not expecting post-processor to have succeeded");
 
-            context.CodeCoverage.AssertExecutedCalled();
+            context.CodeCoverage.AssertExecuteCalled();
             context.Runner.AssertExecuted();
             context.ReportBuilder.AssertExecuted(); // should be called even if the sonar-runner fails
 
@@ -80,7 +80,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             Assert.IsTrue(success, "Expecting post-processor to have succeeded");
 
             context.CodeCoverage.AssertInitializedCalled();
-            context.CodeCoverage.AssertExecutedCalled();
+            context.CodeCoverage.AssertExecuteCalled();
             context.Runner.AssertExecuted();
             context.ReportBuilder.AssertExecuted(); // should be called even if the sonar-runner fails
 
@@ -107,7 +107,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             Assert.IsTrue(success, "Expecting post-processor to have succeeded");
 
             context.CodeCoverage.AssertInitializedCalled();
-            context.CodeCoverage.AssertExecutedNotCalled();
+            context.CodeCoverage.AssertExecuteNotCalled();
             context.Runner.AssertExecuted();
             context.ReportBuilder.AssertExecuted(); // should be called even if the sonar-runner fails
 
@@ -132,7 +132,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             Assert.IsFalse(success, "Expecting post-processor to have failed");
 
             context.CodeCoverage.AssertInitialisedNotCalled();
-            context.CodeCoverage.AssertExecutedNotCalled();
+            context.CodeCoverage.AssertExecuteNotCalled();
             context.Runner.AssertNotExecuted();
             context.ReportBuilder.AssertNotExecuted();
 
@@ -170,7 +170,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             // Assert
             Assert.IsTrue(success, "Expecting post-processor to have succeeded");
 
-            context.CodeCoverage.AssertExecutedCalled();
+            context.CodeCoverage.AssertExecuteCalled();
             context.CodeCoverage.AssertInitializedCalled();
             context.Runner.AssertExecuted();
             context.ReportBuilder.AssertExecuted();

--- a/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarQube.TeamBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -114,9 +114,7 @@ namespace SonarQube.TeamBuild.PostProcessor.Tests
             CollectionAssert.AreEqual(new string[] { }, context.Runner.SuppliedCommandLineArgs.ToArray(), "Unexpected command line args passed to the sonar-runner");
 
             context.Logger.AssertErrorsLogged(0);
-            context.Logger.AssertWarningsLogged(1);
-            context.Logger.AssertSingleWarningExists("coverage");
-
+            context.Logger.AssertWarningsLogged(0);
         }
 
         [TestMethod]


### PR DESCRIPTION
If VS is not installed on the agent machine you get a NullReferenceException. But even if you fix that, the analysis will fail - the root cause being that the code coverage processor does not distinguish between initialization errors such as "no VS on the machine - i.e. no coverage converter tool" and actual processing errors. So I changed the flow to take into account the 2 types of failures.