### PR TITLE
[SONARMSBRU-139] Modified the "incompatible version" error message

### DIFF
--- a/SonarQube.Bootstrapper/Resources.Designer.cs
+++ b/SonarQube.Bootstrapper/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace SonarQube.Bootstrapper {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The C# plugin installed on the server is not compatible with the MSBuild.SonarQube.Runner.exe - either check the compatibility matrix or get the latest versions for both. .
+        ///   Looks up a localized string similar to The C# plugin installed on the SonarQube server is not compatible with the SonarQube analysis agent (i.e. the MSBuild.SonarQube.Runner.exe, or the build automation task). Either check the compatibility matrix or get the latest versions for both..
         /// </summary>
         public static string ERROR_VersionMismatch {
             get {

--- a/SonarQube.Bootstrapper/Resources.resx
+++ b/SonarQube.Bootstrapper/Resources.resx
@@ -136,7 +136,7 @@
     <value>{0} failed. Exit code: {1}</value>
   </data>
   <data name="ERROR_VersionMismatch" xml:space="preserve">
-    <value>The C# plugin installed on the server is not compatible with the MSBuild.SonarQube.Runner.exe - either check the compatibility matrix or get the latest versions for both. </value>
+    <value>The C# plugin installed on the SonarQube server is not compatible with the SonarQube analysis agent (i.e. the MSBuild.SonarQube.Runner.exe, or the build automation task). Either check the compatibility matrix or get the latest versions for both.</value>
   </data>
   <data name="MSG_CheckingForUpdates" xml:space="preserve">
     <value>Checking for updates...</value>


### PR DESCRIPTION
I considered emitting a different error message based on the build environment (i.e. Build vNext / other).
However, the code that does the build environment check is in TeamBuild.Integration assembly which isn't referenced by the bootstrapper. Simply changing the string seems like a better option at this point.