### PR TITLE
Find the TRX from the project sonar.cs.vstest.reports.Paths property

### DIFF
--- a/SonarQube.TeamBuild.Integration/BuildVNextCoverageReportProcessor.cs
+++ b/SonarQube.TeamBuild.Integration/BuildVNextCoverageReportProcessor.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using SonarQube.Common;
-using System;
 
 namespace SonarQube.TeamBuild.Integration
 {
@@ -28,12 +27,22 @@ namespace SonarQube.TeamBuild.Integration
         #endregion
 
         #region Overrides
-        
+
         protected override bool TryGetBinaryReportFile(AnalysisConfig config, TeamBuildSettings settings, ILogger logger, out string binaryFilePath)
         {
-            binaryFilePath = TrxFileReader.LocateCodeCoverageFile(settings.BuildDirectory, logger);
+            Property vstestReportPath = getVstestReportPathOption(config);
+
+            binaryFilePath = TrxFileReader.LocateCodeCoverageFile(settings.BuildDirectory, logger, vstestReportPath);
 
             return true; // there aren't currently any conditions under which we'd want to stop processing
+        }
+
+        private static Property getVstestReportPathOption(AnalysisConfig config)
+        {
+            var analysisConfig = config.GetAnalysisSettings(true);
+            Property vstestReportPath;
+            analysisConfig.TryGetProperty("sonar.cs.vstest.reportsPaths", out vstestReportPath);
+            return vstestReportPath;
         }
 
         #endregion

--- a/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
+++ b/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
@@ -54,6 +54,10 @@
   <!-- End of Team Foundation references -->
   <!-- ***************************************************************** -->
   <ItemGroup>
+    <Reference Include="Minimatch, Version=1.1.0.0, Culture=neutral, PublicKeyToken=0cadeb0b849c27c0, processorArchitecture=MSIL">
+      <HintPath>..\packages\Minimatch.1.1.0.0\lib\portable-net40+sl50+win+wp80\Minimatch.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -102,7 +106,13 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="..\packages\Minimatch.1.1.0.0\lib\portable-net40+sl50+win+wp80\Minimatch.dll">
+      <Link>Minimatch.dll</Link>
+    </EmbeddedResource>
     <Content Include="License.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SonarQube.TeamBuild.Integration/packages.config
+++ b/SonarQube.TeamBuild.Integration/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Minimatch" version="1.1.0.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
If the user has specified the option sonar.cs.vstest.reports.Paths property, there is the possibility that she's right. 

This pull request allows the processing of the specified trx file, if any file in the build directory matches the given minimatch expression.