### PR TITLE
[SONARMSBRU-150] Log exe versions

### DIFF
--- a/SonarQube.Bootstrapper/Program.cs
+++ b/SonarQube.Bootstrapper/Program.cs
@@ -17,6 +17,7 @@ namespace SonarQube.Bootstrapper
         private static int Main(string[] args)
         {
             var logger = new ConsoleLogger();
+            Utilities.LogAssemblyVersion(logger, typeof(Program).Assembly, Resources.AssemblyDescription);
             BuildAgentUpdater updater = new BuildAgentUpdater();
             return Execute(args, updater, logger);
         }

--- a/SonarQube.Bootstrapper/Resources.Designer.cs
+++ b/SonarQube.Bootstrapper/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarQube.Bootstrapper {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSBuild SonarQube Runner Bootstrapper.
+        /// </summary>
+        public static string AssemblyDescription {
+            get {
+                return ResourceManager.GetString("AssemblyDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to begin - perform pre-MSBuild analysis steps.
         /// </summary>
         public static string CmdLine_ArgDescription_Begin {

--- a/SonarQube.Bootstrapper/Resources.resx
+++ b/SonarQube.Bootstrapper/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AssemblyDescription" xml:space="preserve">
+    <value>MSBuild SonarQube Runner Bootstrapper</value>
+  </data>
   <data name="CmdLine_ArgDescription_Begin" xml:space="preserve">
     <value>begin - perform pre-MSBuild analysis steps</value>
   </data>

--- a/SonarQube.Common/Utilities.cs
+++ b/SonarQube.Common/Utilities.cs
@@ -179,6 +179,25 @@ namespace SonarQube.Common
 
             return false;
         }
+
+        public static void LogAssemblyVersion(ILogger logger, System.Reflection.Assembly assembly, string description)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
+            }
+            if (assembly == null)
+            {
+                throw new ArgumentNullException("asm");
+            }
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                throw new ArgumentNullException("description");
+            }
+
+            logger.LogInfo("{0} {1}", description, assembly.GetName().Version);
+        }
+
         #endregion
 
     }

--- a/SonarQube.Common/Utilities.cs
+++ b/SonarQube.Common/Utilities.cs
@@ -188,7 +188,7 @@ namespace SonarQube.Common
             }
             if (assembly == null)
             {
-                throw new ArgumentNullException("asm");
+                throw new ArgumentNullException("assembly");
             }
             if (string.IsNullOrWhiteSpace(description))
             {

--- a/SonarQube.TeamBuild.PostProcessor/Program.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Program.cs
@@ -20,7 +20,9 @@ namespace SonarQube.TeamBuild.PostProcessor
 
         private static int Main(string[] args)
         {
-            ConsoleLogger logger = new ConsoleLogger(includeTimestamp: true);
+            ConsoleLogger logger = new ConsoleLogger();
+            Utilities.LogAssemblyVersion(logger, typeof(Program).Assembly, Resources.AssemblyDescription);
+            logger.IncludeTimestamp = true;
 
             TeamBuildSettings settings = TeamBuildSettings.GetSettingsFromEnvironment(logger);
             Debug.Assert(settings != null, "Settings should not be null");

--- a/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarQube.TeamBuild.PostProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSBuild SonarQube Runner Post-processor.
+        /// </summary>
+        internal static string AssemblyDescription {
+            get {
+                return ResourceManager.GetString("AssemblyDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inconsistent build environment settings: the build Uri in the analysis config file does not match the build uri from the environment variable.
         ///Build Uri from environment: {0}
         ///Build Uri from config: {1}

--- a/SonarQube.TeamBuild.PostProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PostProcessor/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AssemblyDescription" xml:space="preserve">
+    <value>MSBuild SonarQube Runner Post-processor</value>
+  </data>
   <data name="ERROR_BuildUrisDontMatch" xml:space="preserve">
     <value>Inconsistent build environment settings: the build Uri in the analysis config file does not match the build uri from the environment variable.
 Build Uri from environment: {0}

--- a/SonarQube.TeamBuild.PreProcessor/Program.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Program.cs
@@ -19,7 +19,9 @@ namespace SonarQube.TeamBuild.PreProcessor
 
         private static int Main(string[] args)
         {
-            ILogger logger = new ConsoleLogger(includeTimestamp: true);
+            ILogger logger = new ConsoleLogger();
+            Utilities.LogAssemblyVersion(logger, typeof(Program).Assembly, Resources.AssemblyDescription);
+            logger.IncludeTimestamp = true;
 
             TeamBuildPreProcessor preProcessor = new TeamBuildPreProcessor();
             bool success = preProcessor.Execute(args, logger);

--- a/SonarQube.TeamBuild.PreProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarQube.TeamBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSBuild SonarQube Runner Pre-processor.
+        /// </summary>
+        public static string AssemblyDescription {
+            get {
+                return ResourceManager.GetString("AssemblyDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /install:[true|false] - install standard MSBuild targets required for analysis (default true).
         /// </summary>
         public static string CmdLine_ArgDescription_InstallTargets {

--- a/SonarQube.TeamBuild.PreProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PreProcessor/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AssemblyDescription" xml:space="preserve">
+    <value>MSBuild SonarQube Runner Pre-processor</value>
+  </data>
   <data name="CmdLine_ArgDescription_InstallTargets" xml:space="preserve">
     <value>/install:[true|false] - install standard MSBuild targets required for analysis (default true)</value>
   </data>


### PR DESCRIPTION
The bootstrapper and pre- and post- processors all now log their version numbers when they start executing. The message format is consistent with the equivalent logging by the sonar-runner, as is the logging level ("info") e.g.

MSBuild SonarQube Runner Bootstrapper 1.0.1.0
SonarQube Runner 2.4
Java 1.7.0_79 Oracle Corporation (64-bit)