### PR TITLE
Update targets files to override Roslyn code analysis properties

### DIFF
--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -411,6 +411,7 @@
   <!-- Set the properties required to run Roslyn analysis as part of the build. -->
   <Target Name="OverrideRoslynCodeAnalysisProperties"
         Condition=" $(SonarQubeTempPath) != '' "
+        DependsOnTargets="SonarQubeCategoriseProject"
         BeforeTargets="Compile" >
 
 

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -416,10 +416,8 @@
 
 
     <PropertyGroup>
-      <SonarQubeRoslynRuleSet>$(SonarQubeConfigPath)</SonarQubeRoslynRuleSet>
-
       <!-- Check if the ruleset exists -->
-      <SonarQubeRoslynRulesetFullName>$(SonarQubeConfigPath)SonarQube.Roslyn-cs.ruleset</SonarQubeRoslynRulesetFullName>
+      <SonarQubeRoslynRulesetFullName>$(SonarQubeConfigPath)SonarQubeRoslyn-cs.ruleset</SonarQubeRoslynRulesetFullName>
       <SonarQubeRoslynRulesetExists>$([System.IO.File]::Exists($(SonarQubeRoslynRulesetFullName)))</SonarQubeRoslynRulesetExists>
       
       <!-- Run FxCop only if the ruleset exists (else it means no Roslyn rules are enabled) -->

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -262,9 +262,26 @@
        OutputFolder="$(ProjectSpecificDir)" />
   </Target>
 
+  <!-- **************************************************************************** -->
+  <!-- Code analysis -->
+  <!-- **************************************************************************** -->
+  <!--  Implementation notes:
+  
+        We want to override any code analysis-related properties that are set in the
+        project file. To do this, we need to execute our targets at the correct
+        point in the build.
+  
+        Note that both the FxCop and Roslyn targets use a property called "CodeAnalysisRuleSet".
+        The FxCop targets use this value directly. However, the Rolsyn targets use it 
+        as input to the "ResolveCodeAnalysisRuleSet" target, which sets the property
+        "ResolvedCodeAnalysisRuleset".
+
+        To avoid complications, we override the property "CodeAnalysisRuleset" with the path to our FxCop ruleset.
+        We override the property "ResolveCodeAnalysisRuleSet" with the path to our Roslyn ruleset.
+  -->
 
   <!-- **************************************************************************** -->
-  <!-- FxCop -->
+  <!-- Code analysis - FxCop -->
   <!-- **************************************************************************** -->
   <!-- We want to control whether or FxCop analysis is run or not, and we want to control
        the ruleset that is used.
@@ -372,6 +389,73 @@
   <!-- End of FxCop section-->
   <!-- **************************************************************************** -->
 
+  <!-- **************************************************************************** -->
+  <!-- Roslyn analysis section -->
+  <!-- **************************************************************************** -->
+  <!-- Set the properties required to run Roslyn analysis as part of the build. 
+       Note: Roslyn analysis is run using the CSC task in MSBuild 14.0 onwards.
+       Analysis is controlled by the following properties:
+         ResolvedCodeAnalysisRuleSet - the full path to the ruleset to use
+         ErrorLog - the file path for the error reporting file
+         
+       We want to run after the core "ResolveCodeAnalysisRuleSet" target which
+       assigns a value to "ResolvedCodeAnalysisRuleSet".
+  -->
+  <Target Name="OverrideRoslynCodeAnalysisProperties"
+        Condition=" $(SonarQubeTempPath) != '' "
+        DependsOnTargets="SonarQubeCategoriseProject"
+        AfterTargets="ResolveCodeAnalysisRuleSet"
+        BeforeTargets="CoreCompile">
+
+    <PropertyGroup>
+      <!-- Check if the ruleset exists -->
+      <SonarQubeRoslynRulesetFullName>$(SonarQubeConfigPath)SonarQubeRoslyn-cs.ruleset</SonarQubeRoslynRulesetFullName>
+      <SonarQubeRoslynRulesetExists>$([System.IO.File]::Exists($(SonarQubeRoslynRulesetFullName)))</SonarQubeRoslynRulesetExists>
+
+      <!-- Run FxCop only if the ruleset exists (else it means no Roslyn rules are enabled) -->
+      <SonarQubeRunRoslynCodeAnalysis>$(SonarQubeRoslynRulesetExists)</SonarQubeRunRoslynCodeAnalysis>
+
+      <!-- For the time being only run for C# -->
+      <SonarQubeRunRoslynCodeAnalysis Condition=" $(Language) != 'C#' ">false</SonarQubeRunRoslynCodeAnalysis>
+
+      <!-- Don't run FxCop if the project is excluded -->
+      <SonarQubeRunRoslynCodeAnalysis Condition=" $(SonarQubeExclude) == 'true' ">false</SonarQubeRunRoslynCodeAnalysis>
+
+      <!-- Don't run FxCop if the project is a test one -->
+      <SonarQubeRunRoslynCodeAnalysis Condition=" $(SonarQubeTestProject) == 'true' ">false</SonarQubeRunRoslynCodeAnalysis>
+
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" $(SonarQubeRunRoslynCodeAnalysis) != 'true' ">
+      <ErrorLog></ErrorLog>
+      <ResolvedCodeAnalysisRuleSet></ResolvedCodeAnalysisRuleSet>
+
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" $(SonarQubeRunRoslynCodeAnalysis) == 'true' ">
+      <ErrorLog Condition=" $(ErrorLog) == '' " >$(TargetDir)SonarQube.Roslyn.ErrorLog.json</ErrorLog>
+      <ResolvedCodeAnalysisRuleSet>$(SonarQubeRoslynRulesetFullName)</ResolvedCodeAnalysisRuleSet>
+    </PropertyGroup>
+
+  </Target>
+
+  <Target Name="SetRoslynAnalysisResults"
+      Condition=" $(SonarQubeTempPath) != '' "
+      AfterTargets="Build"
+      BeforeTargets="WriteSonarQubeProjectData" >
+
+    <ItemGroup>
+      <SonarQubeSetting Include="sonar.cs.roslyn.reportFilePath"
+         Condition=" $(ErrorLog) != '' AND  $([System.IO.File]::Exists($(ErrorLog))) == 'true' ">
+        <Value>$(ErrorLog)</Value>
+      </SonarQubeSetting>
+    </ItemGroup>
+
+  </Target>
+  <!-- **************************************************************************** -->
+  <!-- End of Roslyn analysis section-->
+  <!-- **************************************************************************** -->
+
 
   <!-- **************************************************************************** -->
   <!-- StyleCop -->
@@ -404,63 +488,5 @@
   <!-- End of StyleCop section-->
   <!-- **************************************************************************** -->
 
-
-  <!-- **************************************************************************** -->
-  <!-- Roslyn analysis section -->
-  <!-- **************************************************************************** -->
-  <!-- Set the properties required to run Roslyn analysis as part of the build. -->
-  <Target Name="OverrideRoslynCodeAnalysisProperties"
-        Condition=" $(SonarQubeTempPath) != '' "
-        DependsOnTargets="SonarQubeCategoriseProject"
-        BeforeTargets="ResolveCodeAnalysisRuleSet" >
-
-
-    <PropertyGroup>
-      <!-- Check if the ruleset exists -->
-      <SonarQubeRoslynRulesetFullName>$(SonarQubeConfigPath)SonarQubeRoslyn-cs.ruleset</SonarQubeRoslynRulesetFullName>
-      <SonarQubeRoslynRulesetExists>$([System.IO.File]::Exists($(SonarQubeRoslynRulesetFullName)))</SonarQubeRoslynRulesetExists>
-      
-      <!-- Run FxCop only if the ruleset exists (else it means no Roslyn rules are enabled) -->
-      <SonarQubeRunRoslynCodeAnalysis>$(SonarQubeRoslynRulesetExists)</SonarQubeRunRoslynCodeAnalysis>
-
-      <!-- For the time being only run for C# -->
-      <SonarQubeRunRoslynCodeAnalysis Condition=" $(Language) != 'C#' ">false</SonarQubeRunRoslynCodeAnalysis>
-
-      <!-- Don't run FxCop if the project is excluded -->
-      <SonarQubeRunRoslynCodeAnalysis Condition=" $(SonarQubeExclude) == 'true' ">false</SonarQubeRunRoslynCodeAnalysis>
-
-      <!-- Don't run FxCop if the project is a test one -->
-      <SonarQubeRunRoslynCodeAnalysis Condition=" $(SonarQubeTestProject) == 'true' ">false</SonarQubeRunRoslynCodeAnalysis>
-
-    </PropertyGroup>
-    
-    <PropertyGroup Condition=" $(SonarQubeRunRoslynCodeAnalysis) != 'true' ">
-      <ErrorLog></ErrorLog>
-      <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" $(SonarQubeRunRoslynCodeAnalysis) == 'true' ">
-      <ErrorLog Condition=" $(ErrorLog) == '' " >$(TargetDir)SonarQube.Roslyn.ErrorLog.xml</ErrorLog>
-      <CodeAnalysisRuleSet>$(SonarQubeRoslynRulesetFullName)</CodeAnalysisRuleSet>
-    </PropertyGroup>
-   
-  </Target>
-
-  <Target Name="SetRoslynAnalysisResults"
-      Condition=" $(SonarQubeTempPath) != '' "
-      AfterTargets="Build"
-      BeforeTargets="WriteSonarQubeProjectData" >
-
-    <ItemGroup>
-      <SonarQubeSetting Include="sonar.cs.roslyn.reportFilePath"
-         Condition=" $(ErrorLog) != '' AND  $([System.IO.File]::Exists($(ErrorLog))) == 'true' ">
-         <Value>$(ErrorLog)</Value>
-      </SonarQubeSetting>
-    </ItemGroup>
-    
-  </Target>
-  <!-- **************************************************************************** -->
-  <!-- End of Roslyn analysis section-->
-  <!-- **************************************************************************** -->
 
 </Project>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -412,7 +412,7 @@
   <Target Name="OverrideRoslynCodeAnalysisProperties"
         Condition=" $(SonarQubeTempPath) != '' "
         DependsOnTargets="SonarQubeCategoriseProject"
-        BeforeTargets="Compile" >
+        BeforeTargets="ResolveCodeAnalysisRuleSet" >
 
 
     <PropertyGroup>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -404,4 +404,23 @@
   <!-- End of StyleCop section-->
   <!-- **************************************************************************** -->
 
+
+  <!-- **************************************************************************** -->
+  <!-- Roslyn analysis section -->
+  <!-- **************************************************************************** -->
+  <!-- Set the properties required to run Roslyn analysis as part of the build. -->
+  <Target Name="SetRoslynAnalysisSettings"
+        Condition=" $(SonarQubeTempPath) != '' "
+        BeforeTargets="Compile" >
+
+    <!-- Work out if the item has already been set -->
+    <PropertyGroup Condition="$(ErrorLog) != '' ">
+      <ErrorLog Condition=" $(ErrorLog) == '' " >$(TargetDir)\SonarQube.Roslyn.ErrorLog.xml</ErrorLog>
+    </PropertyGroup>
+   
+  </Target>
+  <!-- **************************************************************************** -->
+  <!-- End of Roslyn analysis section-->
+  <!-- **************************************************************************** -->
+
 </Project>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -409,15 +409,56 @@
   <!-- Roslyn analysis section -->
   <!-- **************************************************************************** -->
   <!-- Set the properties required to run Roslyn analysis as part of the build. -->
-  <Target Name="SetRoslynAnalysisSettings"
+  <Target Name="OverrideRoslynCodeAnalysisProperties"
         Condition=" $(SonarQubeTempPath) != '' "
         BeforeTargets="Compile" >
 
-    <!-- Work out if the item has already been set -->
-    <PropertyGroup Condition="$(ErrorLog) != '' ">
-      <ErrorLog Condition=" $(ErrorLog) == '' " >$(TargetDir)\SonarQube.Roslyn.ErrorLog.xml</ErrorLog>
+
+    <PropertyGroup>
+      <SonarQubeRoslynRuleSet>$(SonarQubeConfigPath)</SonarQubeRoslynRuleSet>
+
+      <!-- Check if the ruleset exists -->
+      <SonarQubeRoslynRulesetFullName>$(SonarQubeConfigPath)SonarQube.Roslyn-cs.ruleset</SonarQubeRoslynRulesetFullName>
+      <SonarQubeRoslynRulesetExists>$([System.IO.File]::Exists($(SonarQubeRoslynRulesetFullName)))</SonarQubeRoslynRulesetExists>
+      
+      <!-- Run FxCop only if the ruleset exists (else it means no Roslyn rules are enabled) -->
+      <SonarQubeRunRoslynCodeAnalysis>$(SonarQubeRoslynRulesetExists)</SonarQubeRunRoslynCodeAnalysis>
+
+      <!-- For the time being only run for C# -->
+      <SonarQubeRunRoslynCodeAnalysis Condition=" $(Language) != 'C#' ">false</SonarQubeRunRoslynCodeAnalysis>
+
+      <!-- Don't run FxCop if the project is excluded -->
+      <SonarQubeRunRoslynCodeAnalysis Condition=" $(SonarQubeExclude) == 'true' ">false</SonarQubeRunRoslynCodeAnalysis>
+
+      <!-- Don't run FxCop if the project is a test one -->
+      <SonarQubeRunRoslynCodeAnalysis Condition=" $(SonarQubeTestProject) == 'true' ">false</SonarQubeRunRoslynCodeAnalysis>
+
+    </PropertyGroup>
+    
+    <PropertyGroup Condition=" $(SonarQubeRunRoslynCodeAnalysis) != 'true' ">
+      <ErrorLog></ErrorLog>
+      <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" $(SonarQubeRunRoslynCodeAnalysis) == 'true' ">
+      <ErrorLog Condition=" $(ErrorLog) == '' " >$(TargetDir)SonarQube.Roslyn.ErrorLog.xml</ErrorLog>
+      <CodeAnalysisRuleSet>$(SonarQubeRoslynRulesetFullName)</CodeAnalysisRuleSet>
     </PropertyGroup>
    
+  </Target>
+
+  <Target Name="SetRoslynAnalysisResults"
+      Condition=" $(SonarQubeTempPath) != '' "
+      AfterTargets="Build"
+      BeforeTargets="WriteSonarQubeProjectData" >
+
+    <ItemGroup>
+      <SonarQubeSetting Include="sonar.cs.roslyn.reportFilePath"
+         Condition=" $(ErrorLog) != '' AND  $([System.IO.File]::Exists($(ErrorLog))) == 'true' ">
+         <Value>$(ErrorLog)</Value>
+      </SonarQubeSetting>
+    </ItemGroup>
+    
   </Target>
   <!-- **************************************************************************** -->
   <!-- End of Roslyn analysis section-->

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
@@ -180,7 +180,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
 
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
 
-            string itemPath = CreateTextFile(rootInputFolder, "my.cs", "class myclass{}");
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "my.cs", "class myclass{}");
             projectRoot.AddItem(TargetProperties.ItemType_Compile, itemPath);
             projectRoot.Save();
 
@@ -229,7 +229,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
 
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties, isVBProject: true);
 
-            string itemPath = CreateTextFile(rootInputFolder, "my.vb",
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "my.vb",
 @"Public Class Class1
 
   Public Sub DoStuff()
@@ -286,10 +286,10 @@ End Class");
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
 
             // Add some files to the project
-            string itemPath = CreateTextFile(rootInputFolder, "content1.txt", "aaaa");
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "content1.txt", "aaaa");
             projectRoot.AddItem("Content", itemPath);
 
-            itemPath = CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{} // wrong item type");
+            itemPath = TestUtils.CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{} // wrong item type");
             projectRoot.AddItem("CompileXXX", itemPath);
             
             projectRoot.Save();
@@ -342,7 +342,7 @@ End Class");
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
 
             // Add a file to the project
-            string itemPath = CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
             projectRoot.AddItem(TargetProperties.ItemType_Compile, itemPath);
             projectRoot.Save();
 
@@ -392,7 +392,7 @@ End Class");
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
 
             // Add a file to the project
-            string itemPath = CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
             projectRoot.AddItem(TargetProperties.ItemType_Compile, itemPath);
             projectRoot.Save();
 
@@ -443,7 +443,7 @@ End Class");
             ProjectRootElement projectRoot = BuildUtilities.CreateValidProjectRoot(this.TestContext, rootInputFolder, preImportProperties);
 
             // Add a file to the project
-            string itemPath = CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
             projectRoot.AddItem(TargetProperties.ItemType_Compile, itemPath);
             projectRoot.Save();
 
@@ -508,7 +508,7 @@ End Class");
 
 
             // Add a file to the project
-            string itemPath = CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
+            string itemPath = TestUtils.CreateTextFile(rootInputFolder, "code1.cs", "class myclassXXX{}");
             projectRoot.AddItem(TargetProperties.ItemType_Compile, itemPath);
             projectRoot.Save();
 
@@ -561,13 +561,6 @@ End Class");
 
             File.WriteAllText(fullPath, content);
             this.TestContext.AddResultFile(fullPath);
-        }
-
-        private string CreateTextFile(string rootInputFolder, string fileName, string contents)
-        {
-            string fullPath = Path.Combine(rootInputFolder, fileName);
-            File.WriteAllText(fullPath, contents);
-            return fullPath;
         }
 
         #endregion

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
@@ -97,6 +97,14 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
         }
 
+        public static void AssertAnalysisSettingDoesNotExist(BuildResult actualResult, string settingName)
+        {
+            Assert.IsNotNull(actualResult.ProjectStateAfterBuild, "Test error: ProjectStateAfterBuild should not be null");
+
+            IEnumerable<ProjectItemInstance> matches = actualResult.ProjectStateAfterBuild.GetItemsByItemTypeAndEvaluatedInclude(BuildTaskConstants.SettingItemName, settingName);
+
+            Assert.AreEqual(0, matches.Count(), "Not expected SonarQubeSetting with include value of '{0}' to exist. Actual occurences: {1}", settingName, matches.Count());
+        }
 
         #endregion
 

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -23,7 +23,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string SetFxCopResultsTarget = "SetFxCopAnalysisResult";
 
         public const string DefaultBuildTarget = "Build";
-        
+        public const string CoreCompile = "CoreCompile";
+
         // FxCop
         public const string FxCopTarget = "RunCodeAnalysis";
         public const string FxCopTask = "CodeAnalysis";

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -28,6 +28,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string FxCopTarget = "RunCodeAnalysis";
         public const string FxCopTask = "CodeAnalysis";
 
+        // Roslyn
+        public const string SetRoslynSettingsTarget = "SetRoslynAnalysisSettings";
+
         // StyleCop
         public const string SetStyleCopSettingsTarget = "SetStyleCopAnalysisSettings";
         public const string StyleCopProjectPathItemName = "sonar.stylecop.projectFilePath";
@@ -62,6 +65,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string AssemblyName = "AssemblyName";
 
         public const string IsInTeamBuild = "TF_Build"; // Common to legacy and non-legacy TeamBuilds
+
+        public const string TargetDir = "TargetDir"; // bin directory into which output will be dropped
+        public const string ErrorLog = "ErrorLog"; // file path to which the Roslyn error log should be written
 
         // Legacy TeamBuild environment variables (XAML Builds)
         public const string TfsCollectionUri_Legacy = "TF_BUILD_COLLECTIONURI";

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -29,7 +29,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string FxCopTask = "CodeAnalysis";
 
         // Roslyn
-        public const string SetRoslynSettingsTarget = "SetRoslynAnalysisSettings";
+        public const string OverrideRoslynSettingsTarget = "OverrideRoslynCodeAnalysisProperties";
+        public const string SetRoslynResultsTarget = "SetRoslynAnalysisResults";
 
         // StyleCop
         public const string SetStyleCopSettingsTarget = "SetStyleCopAnalysisSettings";
@@ -68,6 +69,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
         public const string TargetDir = "TargetDir"; // bin directory into which output will be dropped
         public const string ErrorLog = "ErrorLog"; // file path to which the Roslyn error log should be written
+        public const string Language = "Language"; // Language of the project: normally "C#" or "VB"
 
         // Legacy TeamBuild environment variables (XAML Builds)
         public const string TfsCollectionUri_Legacy = "TF_BUILD_COLLECTIONURI";

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -32,6 +32,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         // Roslyn
         public const string OverrideRoslynSettingsTarget = "OverrideRoslynCodeAnalysisProperties";
         public const string SetRoslynResultsTarget = "SetRoslynAnalysisResults";
+        public const string ResolveCodeAnalysisRuleSet = "ResolveCodeAnalysisRuleSet";
 
         // StyleCop
         public const string SetStyleCopSettingsTarget = "SetStyleCopAnalysisSettings";
@@ -67,6 +68,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string AssemblyName = "AssemblyName";
 
         public const string IsInTeamBuild = "TF_Build"; // Common to legacy and non-legacy TeamBuilds
+
+        public const string ResolvedCodeAnalysisRuleset = "ResolvedCodeAnalysisRuleSet";
 
         public const string TargetDir = "TargetDir"; // bin directory into which output will be dropped
         public const string ErrorLog = "ErrorLog"; // file path to which the Roslyn error log should be written

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/SonarQube.MSBuild.Tasks.IntegrationTests.csproj
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/SonarQube.MSBuild.Tasks.IntegrationTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Infrastructure\TargetConstants.cs" />
     <Compile Include="Infrastructure\WellKnownProjectProperties.cs" />
     <Compile Include="TargetsTests\ImportBeforeTargetsTests.cs" />
+    <Compile Include="TargetsTests\RoslynTargetsTests.cs" />
     <Compile Include="TargetsTests\SetStyleCopPropertiesTargetTests.cs" />
     <Compile Include="TargetsTests\SonarIntegrationTargetsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -65,9 +65,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             logger.AssertTargetExecuted(TargetConstants.OverrideRoslynSettingsTarget);
             BuildAssertions.AssertTargetSucceeded(result, TargetConstants.OverrideRoslynSettingsTarget);
 
-            // Check the ruleset and error log are not set
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ErrorLog, string.Empty);
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.CodeAnalysisRuleset, string.Empty);
+            AssertCodeAnalysisIsDisabled(result);
         }
 
         [TestMethod]
@@ -162,14 +160,12 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarQubeRoslynRulesetExists", "True");
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarQubeRunRoslynCodeAnalysis", "false");
 
-            // Check the error log and ruleset properties are set
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ErrorLog, string.Empty);
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.CodeAnalysisRuleset, string.Empty);
+            AssertCodeAnalysisIsDisabled(result);
         }
 
         [TestMethod]
         [Description("Checks the code analysis properties are cleared for excludedprojects")]
-        public void Roslyn_Settings_NotRunForExlucdedProject()
+        public void Roslyn_Settings_NotRunForExcludedProject()
         {
             // Arrange
             string rootInputFolder = TestUtils.CreateTestSpecificFolder(this.TestContext, "Inputs");
@@ -196,9 +192,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarQubeRoslynRulesetExists", "True");
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarQubeRunRoslynCodeAnalysis", "false");
 
-            // Check the error log and ruleset properties are set
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ErrorLog, string.Empty);
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.CodeAnalysisRuleset, string.Empty);
+            AssertCodeAnalysisIsDisabled(result);
         }
 
         #endregion
@@ -323,7 +317,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             {
                 Directory.CreateDirectory(configFolder);
             }
-            string rulesetFilePath = TestUtils.CreateTextFile(configFolder, "SonarQube.Roslyn-cs.ruleset", "dummy rules");
+            string rulesetFilePath = TestUtils.CreateTextFile(configFolder, "SonarQubeRoslyn-cs.ruleset", "dummy rules");
             return rulesetFilePath;
         }
 
@@ -335,5 +329,15 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
         #endregion
 
+        #region Checks
+
+        private static void AssertCodeAnalysisIsDisabled(BuildResult result)
+        {
+            // Check the ruleset and error log are not set
+            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ErrorLog, string.Empty);
+            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.CodeAnalysisRuleset, string.Empty);
+        }
+
+        #endregion
     }
 }

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -97,9 +97,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
             // Check the error log and ruleset properties are set
             string targetDir = result.ProjectStateAfterBuild.GetPropertyValue(TargetProperties.TargetDir);
-            string expectedErrorLog = Path.Combine(targetDir, "SonarQube.Roslyn.ErrorLog.xml");
+            string expectedErrorLog = Path.Combine(targetDir, "SonarQube.Roslyn.ErrorLog.json");
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ErrorLog, expectedErrorLog);
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.CodeAnalysisRuleset, rulesetFilePath);
+            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ResolvedCodeAnalysisRuleset, rulesetFilePath);
         }
 
         [TestMethod]
@@ -299,9 +299,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget);
             logger.AssertTargetExecuted(TargetConstants.OverrideRoslynSettingsTarget);
             logger.AssertExpectedTargetOrdering(
+                TargetConstants.ResolveCodeAnalysisRuleSet,
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.OverrideRoslynSettingsTarget,
-                "ResolveCodeAnalysisRuleSet",
                 TargetConstants.CoreCompile,
                 TargetConstants.DefaultBuildTarget,
                 TargetConstants.SetRoslynResultsTarget,
@@ -337,7 +337,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
         {
             // Check the ruleset and error log are not set
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ErrorLog, string.Empty);
-            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.CodeAnalysisRuleset, string.Empty);
+            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.ResolvedCodeAnalysisRuleset, string.Empty);
         }
 
         #endregion

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -301,6 +301,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             logger.AssertExpectedTargetOrdering(
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.OverrideRoslynSettingsTarget,
+                "ResolveCodeAnalysisRuleSet",
+                TargetConstants.CoreCompile,
                 TargetConstants.DefaultBuildTarget,
                 TargetConstants.SetRoslynResultsTarget,
                 TargetConstants.WriteProjectDataTarget);

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/TrxFileReaderTests.cs
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/TrxFileReaderTests.cs
@@ -43,7 +43,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             // Arrange
             string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
             string resultsDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "TestResults");
-            CreateTextFile(resultsDir, "dummy.trx", "this is not a trx file");
+            TestUtils.CreateTextFile(resultsDir, "dummy.trx", "this is not a trx file");
             TestLogger logger = new TestLogger();
 
             // Act
@@ -62,8 +62,8 @@ namespace SonarQube.TeamBuild.Integration.Tests
             // Arrange
             string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
             string resultsDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "TestResults");
-            string trx1 = CreateTextFile(resultsDir, "mytrx1.trx", "<TestRun />");
-            string trx2 = CreateTextFile(resultsDir, "mytrx2.trx", "<TestRun />");
+            string trx1 = TestUtils.CreateTextFile(resultsDir, "mytrx1.trx", "<TestRun />");
+            string trx2 = TestUtils.CreateTextFile(resultsDir, "mytrx2.trx", "<TestRun />");
             TestLogger logger = new TestLogger();
 
             // Act
@@ -82,7 +82,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             // Arrange
             string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
             string resultsDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "TestResults");
-            string trxFile = CreateTextFile(resultsDir, "no_attachments.trx",
+            string trxFile = TestUtils.CreateTextFile(resultsDir, "no_attachments.trx",
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <TestRun id=""eb906034-f363-4bf0-ac6a-29fa47645f67""
 	name=""LOCAL SERVICE@MACHINENAME 2015-05-06 08:38:39"" runUser=""NT AUTHORITY\LOCAL SERVICE"" xmlns=""http://microsoft.com/schemas/VisualStudio/TeamTest/2010"">
@@ -116,7 +116,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             string testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
             string resultsDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "TestResults");
 
-            CreateTextFile(resultsDir, "multiple_attachments.trx",
+            TestUtils.CreateTextFile(resultsDir, "multiple_attachments.trx",
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <TestRun id=""eb906034-f363-4bf0-ac6a-29fa47645f67""
 	name=""LOCAL SERVICE@MACHINENAME 2015-05-06 08:38:39"" runUser=""NT AUTHORITY\LOCAL SERVICE""
@@ -166,7 +166,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             string resultsDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "TestResults");
             string coverageFileName = "MACHINENAME\\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage";
 
-            CreateTextFile(resultsDir, "single_attachment.trx",
+            TestUtils.CreateTextFile(resultsDir, "single_attachment.trx",
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <TestRun id=""eb906034-f363-4bf0-ac6a-29fa47645f67""
 	name=""LOCAL SERVICE@MACHINENAME 2015-05-06 08:38:39"" runUser=""NT AUTHORITY\LOCAL SERVICE""
@@ -210,7 +210,7 @@ namespace SonarQube.TeamBuild.Integration.Tests
             string resultsDir = TestUtils.CreateTestSpecificFolder(this.TestContext, "TestResults");
             string coverageFileName = "x:\\dir1\\dir2\\xxx.coverage";
 
-            CreateTextFile(resultsDir, "single_attachment.trx",
+            TestUtils.CreateTextFile(resultsDir, "single_attachment.trx",
 @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <TestRun id=""eb906034-f363-4bf0-ac6a-29fa47645f67""
 	name=""LOCAL SERVICE@MACHINENAME 2015-05-06 08:38:39"" runUser=""NT AUTHORITY\LOCAL SERVICE""
@@ -240,25 +240,6 @@ namespace SonarQube.TeamBuild.Integration.Tests
             // Assert
             Assert.AreEqual(coverageFilePath, coverageFilePath);
             logger.AssertDebugMessageExists(coverageFileName);
-        }
-
-        #endregion
-
-        #region Private methods
-
-        private static string CreateTextFile(string parentDir, string fileName, string content, params string[] args)
-        {
-            Assert.IsTrue(Directory.Exists(parentDir), "Test setup error: expecting the parent directory to exist: {0}", parentDir);
-            string fullPath = Path.Combine(parentDir, fileName);
-
-            string formattedContent = content;
-            if (args != null && args.Any())
-            {
-                formattedContent = string.Format(System.Globalization.CultureInfo.InvariantCulture, content, args);
-            }
-
-            File.WriteAllText(fullPath, formattedContent);
-            return fullPath;
         }
 
         #endregion

--- a/Tests/TestUtilities/TestUtils.cs
+++ b/Tests/TestUtilities/TestUtils.cs
@@ -41,6 +41,26 @@ namespace TestUtilities
         }
 
         /// <summary>
+        /// Creates a new text file in the specified directory
+        /// </summary>
+        /// <param name="substitutionArgs">Optional. Arguments that will be substituted into <param name="content">.</param></param>
+        /// <returns>Returns the full path to the created file</returns>
+        public static string CreateTextFile(string parentDir, string fileName, string content, params string[] substitutionArgs)
+        {
+            Assert.IsTrue(Directory.Exists(parentDir), "Test setup error: expecting the parent directory to exist: {0}", parentDir);
+            string fullPath = Path.Combine(parentDir, fileName);
+
+            string formattedContent = content;
+            if (substitutionArgs != null && substitutionArgs.Length > 0)
+            {
+                formattedContent = string.Format(System.Globalization.CultureInfo.InvariantCulture, content, substitutionArgs);
+            }
+
+            File.WriteAllText(fullPath, formattedContent);
+            return fullPath;
+        }
+
+        /// <summary>
         /// Ensures that the ImportBefore targets exist in a test-specific folder
         /// </summary>
         public static string EnsureImportBeforeTargetsExists(TestContext testContext)


### PR DESCRIPTION
The targets now look for a well-known ruleset name on disc and configures the Roslyn analysis based on whether the file exists or not.
Currently the Roslyn ruleset is separate from the FxCop ruleset. The build properties are set appropriately so the correct ruleset is used. However, it might be simpler to generate a single combined ruleset file and use that - I'll see how it works out in practice.