### PR TITLE
SONARMSBRU-156: The process runner becomes solely responsible for quo…

### DIFF
--- a/SonarQube.Bootstrapper/ArgumentProcessor.cs
+++ b/SonarQube.Bootstrapper/ArgumentProcessor.cs
@@ -163,7 +163,7 @@ namespace SonarQube.Bootstrapper
             {
                 Debug.Assert(fileProvider.PropertiesFile != null);
                 Debug.Assert(!string.IsNullOrEmpty(fileProvider.PropertiesFile.FilePath), "Expecting the properties file path to be set");
-                childArgs.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}\"{1}\"", FilePropertyProvider.Prefix, fileProvider.PropertiesFile.FilePath));
+                childArgs.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}{1}", FilePropertyProvider.Prefix, fileProvider.PropertiesFile.FilePath));
             }
 
             IBootstrapperSettings settings = new BootstrapperSettings(

--- a/SonarQube.Bootstrapper/ArgumentProcessor.cs
+++ b/SonarQube.Bootstrapper/ArgumentProcessor.cs
@@ -209,7 +209,7 @@ namespace SonarQube.Bootstrapper
         {
             if (commandLineArgs == null)
             {
-                throw new ArgumentNullException("param");
+                throw new ArgumentNullException("commandLineArgs");
             }
 
             var excludedVerbs = new string[] { BeginVerb, EndVerb };

--- a/SonarQube.Common/AnalysisProperties/Property.cs
+++ b/SonarQube.Common/AnalysisProperties/Property.cs
@@ -51,7 +51,7 @@ namespace SonarQube.Common
         /// </summary>
         public string AsSonarRunnerArg()
         {
-            return string.Format(System.Globalization.CultureInfo.InvariantCulture, "-D{0}={1}", this.Id, ProcessRunnerArguments.GetQuotedArg(this.Value));
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, "-D{0}={1}", this.Id, this.Value);
         }
 
         #endregion

--- a/SonarQube.Common/ProcessRunner.cs
+++ b/SonarQube.Common/ProcessRunner.cs
@@ -81,7 +81,7 @@ namespace SonarQube.Common
                 // may contain sensitive data
                 this.outputLogger.LogDebug(Resources.MSG_ExecutingFile,
                     runnerArgs.ExeName,
-                    runnerArgs.GetCommandLineArgsLogText(),
+                    runnerArgs.AsLogText(),
                     runnerArgs.WorkingDirectory,
                     runnerArgs.TimeoutInMilliseconds,
                     process.Id);

--- a/SonarQube.Common/ProcessRunner.cs
+++ b/SonarQube.Common/ProcessRunner.cs
@@ -38,7 +38,7 @@ namespace SonarQube.Common
                 throw new ArgumentNullException("runnerArgs");
             }
             Debug.Assert(!string.IsNullOrWhiteSpace(runnerArgs.ExeName), "Process runner exe name should not be null/empty");
-            Debug.Assert( runnerArgs.Logger!= null, "Process runner logger should not be null/empty");
+            Debug.Assert(runnerArgs.Logger != null, "Process runner logger should not be null/empty");
 
             this.outputLogger = runnerArgs.Logger;
 
@@ -60,11 +60,6 @@ namespace SonarQube.Common
                 Arguments = runnerArgs.GetQuotedCommandLineArgs(),
                 WorkingDirectory = runnerArgs.WorkingDirectory
             };
-
-
-            //string tempString = runnerArgs.CmdLineArgs != null ? String.Join(" ", runnerArgs.CmdLineArgs) : "";
-            //this.outputLogger.LogInfo("UNQUOTED ARGS: " + tempString);
-            //this.outputLogger.LogInfo("QUOTED ARGS: " + psi.Arguments);
 
             SetEnvironmentVariables(psi, runnerArgs.EnvironmentVariables, runnerArgs.Logger);
 
@@ -122,7 +117,7 @@ namespace SonarQube.Common
             return succeeded;
         }
 
-        #endregion
+        #endregion Public methods
 
         #region Private methods
 
@@ -168,6 +163,6 @@ namespace SonarQube.Common
             }
         }
 
-        #endregion
+        #endregion Private methods
     }
 }

--- a/SonarQube.Common/ProcessRunner.cs
+++ b/SonarQube.Common/ProcessRunner.cs
@@ -61,6 +61,11 @@ namespace SonarQube.Common
                 WorkingDirectory = runnerArgs.WorkingDirectory
             };
 
+
+            //string tempString = runnerArgs.CmdLineArgs != null ? String.Join(" ", runnerArgs.CmdLineArgs) : "";
+            //this.outputLogger.LogInfo("UNQUOTED ARGS: " + tempString);
+            //this.outputLogger.LogInfo("QUOTED ARGS: " + psi.Arguments);
+
             SetEnvironmentVariables(psi, runnerArgs.EnvironmentVariables, runnerArgs.Logger);
 
             bool succeeded;

--- a/SonarQube.Common/ProcessRunnerArguments.cs
+++ b/SonarQube.Common/ProcessRunnerArguments.cs
@@ -75,7 +75,7 @@ namespace SonarQube.Common
         {
             if (this.CmdLineArgs == null) { return null; }
 
-            return string.Join(" ", this.CmdLineArgs.Select(a => GetQuotedArg(a)));
+            return string.Join(" ", this.CmdLineArgs.Select(a => EscapeArgument(a)));
         }
 
         /// <summary>
@@ -127,18 +127,17 @@ namespace SonarQube.Common
             return SensitivePropertyKeys.Any(marker => text.IndexOf(marker, StringComparison.OrdinalIgnoreCase) > -1);
         }
 
-        public static string GetQuotedArg(string arg)
+        /// <summary>
+        /// According to https://msdn.microsoft.com/en-us/library/system.diagnostics.processstartinfo.arguments(v=vs.110).aspx
+        /// quotes have to be doubled. Also, to avoid problems when the argument has spaces or chars such as & which are problematic in .bat files, 
+        /// enclose the entire argument in quotes
+        /// </summary>
+        private static string EscapeArgument(string arg)
         {
             Debug.Assert(arg != null, "Not expecting an argument to be null");
-
-            string quotedArg = arg;
-
-            // If an argument contains a quote then we assume it has been correctly quoted.
-            // Otherwise, quote strings that contain spaces.
-            if (quotedArg != null && arg.Contains(' ') && !arg.Contains('"'))
-            {
-                quotedArg = "\"" + arg + "\"";
-            }
+            
+            string quotedArg = arg.Replace("\"", "\"\"");
+            quotedArg = "\"" + quotedArg + "\"";
 
             return quotedArg;
         }

--- a/SonarQube.Common/ProcessRunnerArguments.cs
+++ b/SonarQube.Common/ProcessRunnerArguments.cs
@@ -82,7 +82,7 @@ namespace SonarQube.Common
         /// Returns the string that should be used when logging command line arguments
         /// (sensitive data will have been removed)
         /// </summary>
-        public string GetCommandLineArgsLogText()
+        public string AsLogText()
         {
             if (this.CmdLineArgs == null) { return null; }
 

--- a/SonarRunner.Shim/SonarRunner.Wrapper.cs
+++ b/SonarRunner.Shim/SonarRunner.Wrapper.cs
@@ -58,7 +58,7 @@ namespace SonarRunner.Shim
             }
             if (userCmdLineArguments == null)
             {
-                throw new ArgumentNullException("cmdLineArguments");
+                throw new ArgumentNullException("userCmdLineArguments");
             }
             if (logger == null)
             {

--- a/SonarRunner.Shim/SonarRunner.Wrapper.cs
+++ b/SonarRunner.Shim/SonarRunner.Wrapper.cs
@@ -222,7 +222,7 @@ namespace SonarRunner.Shim
             // Experimentation suggests that the sonar-runner won't error if duplicate arguments
             // are supplied - it will just use the last argument.
             // So we'll set our additional properties last to make sure they take precedence.
-            args.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}{1}=\"{2}\"", CmdLineArgPrefix, ProjectSettingsFileArgName, projectSettingsFilePath));
+            args.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}{1}={2}", CmdLineArgPrefix, ProjectSettingsFileArgName, projectSettingsFilePath));
             args.Add(StandardAdditionalRunnerArguments);
 
             return args;

--- a/Tests/SonarQube.Common.UnitTests/ProcessRunnerTests.cs
+++ b/Tests/SonarQube.Common.UnitTests/ProcessRunnerTests.cs
@@ -226,7 +226,10 @@ xxx yyy
                 "\"quoted\"",
                 "\"quoted with spaces\"",
                 "/test:\"quoted arg\"",
-                "unquoted with spaces" };
+                "unquoted with spaces",
+                "quote in \"the middle",
+                "quotes & ampersands",
+                "\"multiple \"\"\"      quotes \" "};
 
             ProcessRunner runner = new ProcessRunner();
 
@@ -241,10 +244,13 @@ xxx yyy
             string exeLogFile = DummyExeHelper.AssertDummyPostProcLogExists(testDir, this.TestContext);
             DummyExeHelper.AssertExpectedLogContents(exeLogFile,
                 "unquoted",
-                "quoted",
-                "quoted with spaces",
-                "/test:quoted arg",
-                "unquoted with spaces");
+                "\"quoted\"",
+                "\"quoted with spaces\"",
+                "/test:\"quoted arg\"",
+                "unquoted with spaces", 
+                "quote in \"the middle",
+                "quotes & ampersands",
+                "\"multiple \"\"\"      quotes \" ");
         }
 
 

--- a/Tests/SonarRunner.Shim.Tests/SonarRunnerWrapperTests.cs
+++ b/Tests/SonarRunner.Shim.Tests/SonarRunnerWrapperTests.cs
@@ -161,7 +161,7 @@ namespace SonarRunner.Shim.Tests
             // Non-sensitive values from the file should not be passed on the command line
             CheckArgDoesNotExist("file.not.sensitive.key", actualCmdLineArgs);
 
-            int dbPwdIndex = CheckArgExists("-Dsonar.jdbc.password=\"file db pwd\"", actualCmdLineArgs); // sensitive value from file
+            int dbPwdIndex = CheckArgExists("-Dsonar.jdbc.password=file db pwd", actualCmdLineArgs); // sensitive value from file
             int userPwdIndex = CheckArgExists("-Dsonar.password=cmdline.password", actualCmdLineArgs); // sensitive value from cmd line: overrides file value
 
             int standardArgsIndex = CheckArgExists(SonarRunnerWrapper.StandardAdditionalRunnerArguments, actualCmdLineArgs);
@@ -204,7 +204,7 @@ namespace SonarRunner.Shim.Tests
         {
             string message = logger.AssertSingleInfoMessageExists(ExpectedConsoleMessagePrefix);
 
-            CheckArgExists("-Dproject.settings=\"" + expectedPropertiesFilePath + "\"", message); // should always be passing the properties file 
+            CheckArgExists("-Dproject.settings=" + expectedPropertiesFilePath, message); // should always be passing the properties file 
             CheckArgExists(SonarRunnerWrapper.StandardAdditionalRunnerArguments, message); // standard args should always be passed
 
             return message;


### PR DESCRIPTION
…ting and escaping args and chars like " and & become valid

Please note that in order to support quotes, spaces and other special chars the simplest way is to quote all arguments before passing them to a process. So -D:key=value becomes "-D:key=value" 

When reviewing, consider passwords such as the ones below (I'll update the bug too)

bog d&a"n
"bog&d&&a""n
"b o|g d&a"n"
bo    	g^"d^^a % %% %%% n

