### PR TITLE
[Technical] Factor out logging adapter class

### DIFF
--- a/SonarQube.MSBuild.Tasks/IsTestFileByName.cs
+++ b/SonarQube.MSBuild.Tasks/IsTestFileByName.cs
@@ -21,7 +21,7 @@ namespace SonarQube.MSBuild.Tasks
     /// </summary>
     /// <remarks>The task applies a regular expression to the file name being tested to determine whether
     /// the file is test file or not. The regular expression used is read from the analysis config file.</remarks>
-    public sealed class IsTestFileByName : Task, SonarQube.Common.ILogger
+    public sealed class IsTestFileByName : Task
     {
         /// <summary>
         /// Id of the SonarQube test setting that specifies the RegEx to use when determining
@@ -117,7 +117,8 @@ namespace SonarQube.MSBuild.Tasks
                 return null;
             }
 
-            bool succeeded = Utilities.Retry(MaxConfigRetryPeriodInMilliseconds, DelayBetweenRetriesInMilliseconds, (SonarQube.Common.ILogger)this, () => DoLoadConfig(fullAnalysisPath, out config));
+            bool succeeded = Utilities.Retry(MaxConfigRetryPeriodInMilliseconds, DelayBetweenRetriesInMilliseconds, 
+                new MSBuildLoggerAdapter(this.Log), () => DoLoadConfig(fullAnalysisPath, out config));
             if (succeeded)
             {
                 this.Log.LogMessage(MessageImportance.Low, Resources.IsTest_ReadingConfigSucceeded, fullAnalysisPath);
@@ -151,53 +152,6 @@ namespace SonarQube.MSBuild.Tasks
             return true;
         }
 
-        private void LogMessage(Common.LoggerVerbosity verbosity, string message, params object[] args)
-        {
-            // We need to adapt between the ILogger verbosity and the MsBuild logger verbosity
-            if (verbosity == Common.LoggerVerbosity.Info)
-            {
-                this.Log.LogMessage(MessageImportance.Normal, message, args);
-            }
-            else
-            {
-                this.Log.LogMessage(MessageImportance.Low, message, args);
-            }
-        }
-
         #endregion Private methods
-
-        #region ILogger interface
-
-        void Common.ILogger.LogWarning(string message, params object[] args)
-        {
-            this.Log.LogWarning(message, args);
-        }
-
-        void Common.ILogger.LogError(string message, params object[] args)
-        {
-            this.Log.LogError(message, args);
-        }
-
-        public void LogDebug(string message, params object[] args)
-        {
-            LogMessage(Common.LoggerVerbosity.Debug, message, args);
-        }
-
-        void Common.ILogger.LogInfo(string message, params object[] args)
-        {
-            LogMessage(Common.LoggerVerbosity.Info, message, args);
-        }
-
-        Common.LoggerVerbosity Common.ILogger.Verbosity
-        {
-            get; set;
-        }
-
-        bool Common.ILogger.IncludeTimestamp
-        {
-            get; set;
-        }
-
-        #endregion ILogger interface
     }
 }

--- a/SonarQube.MSBuild.Tasks/MSBuildLoggerAdapter.cs
+++ b/SonarQube.MSBuild.Tasks/MSBuildLoggerAdapter.cs
@@ -1,0 +1,81 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MSBuildLoggerAdapter.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.Build.Utilities;
+using SonarQube.Common;
+using System;
+
+namespace SonarQube.MSBuild.Tasks
+{
+    /// <summary>
+    /// Adapter that converts between the SonarQube and MSBuild logging interfaces
+    /// </summary>
+    internal class MSBuildLoggerAdapter : ILogger
+    {
+        private readonly TaskLoggingHelper msBuildLogger;
+
+        public MSBuildLoggerAdapter(TaskLoggingHelper msBuildLogger)
+        {
+            if (msBuildLogger == null)
+            {
+                throw new ArgumentNullException("msBuildLogger");
+            }
+            this.msBuildLogger = msBuildLogger;
+        }
+
+        #region SonarQube.Common.ILogger methods
+
+        bool ILogger.IncludeTimestamp
+        {
+            get; set;
+        }
+
+        LoggerVerbosity ILogger.Verbosity
+        {
+            get; set;
+        }
+
+        void ILogger.LogDebug(string message, params object[] args)
+        {
+            this.LogMessage(Common.LoggerVerbosity.Debug, message, args);
+        }
+
+        void ILogger.LogError(string message, params object[] args)
+        {
+            this.msBuildLogger.LogError(message, args);
+        }
+
+        void ILogger.LogInfo(string message, params object[] args)
+        {
+            this.LogMessage(Common.LoggerVerbosity.Info, message, args);
+        }
+
+        void ILogger.LogWarning(string message, params object[] args)
+        {
+            this.msBuildLogger.LogWarning(message, args);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private void LogMessage(Common.LoggerVerbosity verbosity, string message, params object[] args)
+        {
+            // We need to adapt between the ILogger verbosity and the MsBuild logger verbosity
+            if (verbosity == Common.LoggerVerbosity.Info)
+            {
+                this.msBuildLogger.LogMessage(Microsoft.Build.Framework.MessageImportance.Normal, message, args);
+            }
+            else
+            {
+                this.msBuildLogger.LogMessage(Microsoft.Build.Framework.MessageImportance.Low, message, args);
+            }
+        }
+
+        #endregion Private methods
+    }
+}

--- a/SonarQube.MSBuild.Tasks/SonarQube.MSBuild.Tasks.csproj
+++ b/SonarQube.MSBuild.Tasks/SonarQube.MSBuild.Tasks.csproj
@@ -48,6 +48,7 @@
     </Compile>
     <Compile Include="BuildTaskConstants.cs" />
     <Compile Include="IsTestFileByName.cs" />
+    <Compile Include="MSBuildLoggerAdapter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
The IsTestFileByName MSBuild task directly implemented ILogger and mapped the logging methods to the equivalent MSBuild logging methods. I moved this code into a separate logging adapter class so it can be used by other MSBuild tasks.
I haven't added any direct tests for the new adapter class; it's tested indirectly by the task tests.