### PR TITLE
SONARMSBRU-184 Pass the downloaded additional XML file to MSBuild for the Roslyn analyzers

### DIFF
--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -479,6 +479,9 @@
       <!-- Remove any existing references to files called *SonarLint*.dll -->
       <Analyzer Remove="@(Analyzer)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($([System.String]::new('%(Analyzer.Identity)')), 'SonarLint[^\\]*\.dll$', System.Text.RegularExpressions.RegexOptions.IgnoreCase)) " />
       <Analyzer Include="$(SonarLintAnalyzerDir)*SonarLint*.dll" />
+      
+      <!-- Add SonarLint.xml as a Roslyn Additional File so that SonarLint can pick up the right rule parameter values -->
+      <AdditionalFiles Include="$(SonarQubeConfigPath)SonarLint.xml" />
     </ItemGroup>
 
   </Target>

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
@@ -157,7 +157,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
             IEnumerable<ProjectItemInstance> matches = actualResult.ProjectStateAfterBuild.GetItems(itemType);
 
-            BuildUtilities.LogMessage("Analyzers:");
+            BuildUtilities.LogMessage("<{0}> item values:", itemType);
             foreach(ProjectItemInstance item in matches)
             {
                 BuildUtilities.LogMessage("\t{0}", item.EvaluatedInclude);

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -80,6 +80,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string ErrorLog = "ErrorLog"; // file path to which the Roslyn error log should be written
         public const string Language = "Language"; // Language of the project: normally "C#" or "VB"
         public const string AnalyzerItemType = "Analyzer";
+        public const string AdditionalFilesItemType = "AdditionalFiles";
 
         // Legacy TeamBuild environment variables (XAML Builds)
         public const string TfsCollectionUri_Legacy = "TF_BUILD_COLLECTIONURI";


### PR DESCRIPTION
This PR is based on the one of SONARMSBRU-178: https://github.com/SonarSource/sonar-msbuild-runner/pull/156

It adds one commit on top of it - you can visualize only the relevant diff by first going to "Commits" and then click on the 2nd commit.