### PR TITLE
[SONARMSBRU-183] Fixed merge ruleset to resolve relative rulesets usi…

### DIFF
--- a/SonarQube.MSBuild.Tasks/MergeRulesets.cs
+++ b/SonarQube.MSBuild.Tasks/MergeRulesets.cs
@@ -8,6 +8,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -34,6 +35,13 @@ namespace SonarQube.MSBuild.Tasks
         public string PrimaryRulesetFilePath { get; set; }
 
         /// <summary>
+        /// Full path to the directory containing the project file
+        /// </summary>
+        /// <remarks>Required to resolve relative ruleset paths</remarks>
+        [Required]
+        public string ProjectDirectoryPath { get; set; }
+
+        /// <summary>
         /// The full file paths of any rulesets to include. Can be empty, in which case the task is a no-op.
         /// </summary>
         public string[] IncludedRulesetFilePaths { get; set; }
@@ -44,6 +52,9 @@ namespace SonarQube.MSBuild.Tasks
 
         public override bool Execute()
         {
+            Debug.Assert(this.PrimaryRulesetFilePath != null, "[Required] property PrimaryRulesetFilePath should not be null when the task is called from MSBuild");
+            Debug.Assert(this.ProjectDirectoryPath != null, "[Required] property ProjectDirectoryPath should not be null when the task is called from MSBuild");
+
             this.Log.LogMessage(MessageImportance.Low, Resources.MergeRulesets_MergingRulesets);
 
             if (!File.Exists(this.PrimaryRulesetFilePath))
@@ -59,7 +70,11 @@ namespace SonarQube.MSBuild.Tasks
             XDocument ruleset = XDocument.Load(PrimaryRulesetFilePath);
             foreach (string includePath in this.IncludedRulesetFilePaths)
             {
-                EnsureIncludeExists(ruleset, includePath);
+                string resolvedIncludePath = this.TryResolveIncludedRuleset(includePath);
+                if (resolvedIncludePath != null)
+                {
+                    EnsureIncludeExists(ruleset, resolvedIncludePath);
+                }
             }
             this.Log.LogMessage(MessageImportance.Low, Resources.MergeRuleset_SavingUpdatedRuleset, this.PrimaryRulesetFilePath);
             ruleset.Save(this.PrimaryRulesetFilePath);
@@ -70,6 +85,32 @@ namespace SonarQube.MSBuild.Tasks
         #endregion Overrides
 
         #region Private methods
+
+        private string TryResolveIncludedRuleset(string includePath)
+        {
+            string resolvedPath;
+
+            if (Path.IsPathRooted(includePath))
+            {
+                resolvedPath = includePath; // assume rooted paths are correctly set
+            }
+            else
+            {
+                this.Log.LogMessage(MessageImportance.Low, Resources.MergeRulesets_ResolvingRuleset, includePath);
+                resolvedPath = Path.GetFullPath(Path.Combine(this.ProjectDirectoryPath, includePath));
+                if (File.Exists(resolvedPath))
+                {
+                    this.Log.LogMessage(MessageImportance.Low, Resources.MergeRulesets_ResolvedRuleset, resolvedPath);
+                }
+                else
+                {
+                    this.Log.LogMessage(MessageImportance.Low, Resources.MergeRulesets_FailedToResolveRuleset, includePath);
+                    resolvedPath = null;
+                }
+            }
+
+            return resolvedPath;
+        }
 
         private void EnsureIncludeExists(XDocument ruleset, string includePath)
         {

--- a/SonarQube.MSBuild.Tasks/Resources.Designer.cs
+++ b/SonarQube.MSBuild.Tasks/Resources.Designer.cs
@@ -154,6 +154,15 @@ namespace SonarQube.MSBuild.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to locate the specified ruleset: {0}.
+        /// </summary>
+        internal static string MergeRulesets_FailedToResolveRuleset {
+            get {
+                return ResourceManager.GetString("MergeRulesets_FailedToResolveRuleset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Merging rulesets....
         /// </summary>
         internal static string MergeRulesets_MergingRulesets {
@@ -168,6 +177,24 @@ namespace SonarQube.MSBuild.Tasks {
         internal static string MergeRulesets_MissingPrimaryRuleset {
             get {
                 return ResourceManager.GetString("MergeRulesets_MissingPrimaryRuleset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resolved ruleset: {0}.
+        /// </summary>
+        internal static string MergeRulesets_ResolvedRuleset {
+            get {
+                return ResourceManager.GetString("MergeRulesets_ResolvedRuleset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resolving relative ruleset: {0}.
+        /// </summary>
+        internal static string MergeRulesets_ResolvingRuleset {
+            get {
+                return ResourceManager.GetString("MergeRulesets_ResolvingRuleset", resourceCulture);
             }
         }
         

--- a/SonarQube.MSBuild.Tasks/Resources.resx
+++ b/SonarQube.MSBuild.Tasks/Resources.resx
@@ -178,4 +178,13 @@ Error: {1}</value>
   <data name="WPIF_WARN_MissingValueMetadata" xml:space="preserve">
     <value>Analysis setting "{0}" does not have "Value" metadata and will be ignored</value>
   </data>
+  <data name="MergeRulesets_FailedToResolveRuleset" xml:space="preserve">
+    <value>Failed to locate the specified ruleset: {0}</value>
+  </data>
+  <data name="MergeRulesets_ResolvedRuleset" xml:space="preserve">
+    <value>Resolved ruleset: {0}</value>
+  </data>
+  <data name="MergeRulesets_ResolvingRuleset" xml:space="preserve">
+    <value>Resolving relative ruleset: {0}</value>
+  </data>
 </root>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -467,6 +467,7 @@
     <MergeRuleSets Condition=" $(SonarLintFound) == 'true' AND $(ResolvedCodeAnalysisRuleSet) != ''"
                    PrimaryRulesetFilePath="$(SonarQubeRoslynRulesetFullName)"
                    IncludedRulesetFilePaths="$(ResolvedCodeAnalysisRuleSet)"
+                   ProjectDirectoryPath="$(MSBuildProjectDirectory)"
                    />
    
     <PropertyGroup Condition=" $(SonarLintFound) == 'true' ">


### PR DESCRIPTION
…ng the project directory

If the user has specified a relative path to a ruleset in the project file then we need to resolve it relative to the project file, since our ruleset is in a different location.