### PR TITLE
[SONARMSBRU-200] Merged ruleset is save to a new file

### DIFF
--- a/SonarQube.MSBuild.Tasks/Resources.Designer.cs
+++ b/SonarQube.MSBuild.Tasks/Resources.Designer.cs
@@ -136,6 +136,15 @@ namespace SonarQube.MSBuild.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to merge rulesets. A ruleset with the specified name already exists: {0}.
+        /// </summary>
+        internal static string MergeRuleset_MergedRulesetAlreadyExists {
+            get {
+                return ResourceManager.GetString("MergeRuleset_MergedRulesetAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No rulesets were specified for inclusion.
         /// </summary>
         internal static string MergeRuleset_NoRulesetsSpecified {

--- a/SonarQube.MSBuild.Tasks/Resources.resx
+++ b/SonarQube.MSBuild.Tasks/Resources.resx
@@ -187,4 +187,7 @@ Error: {1}</value>
   <data name="MergeRulesets_ResolvingRuleset" xml:space="preserve">
     <value>Resolving relative ruleset: {0}</value>
   </data>
+  <data name="MergeRuleset_MergedRulesetAlreadyExists" xml:space="preserve">
+    <value>Failed to merge rulesets. A ruleset with the specified name already exists: {0}</value>
+  </data>
 </root>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -463,13 +463,31 @@
           ">true</SonarLintFound>
       <SonarLintFound Condition=" $(SonarLintFound) == '' ">false</SonarLintFound>
     </PropertyGroup>
-    
-    <MergeRuleSets Condition=" $(SonarLintFound) == 'true' AND $(ResolvedCodeAnalysisRuleSet) != ''"
+
+    <PropertyGroup>
+      <RulesetMergeRequired Condition=" $(SonarLintFound) == 'true' AND $(ResolvedCodeAnalysisRuleSet) != ''">true</RulesetMergeRequired>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(RulesetMergeRequired) == 'true' ">
+      <!-- Calculate a unique name for the merged ruleset -->
+      <!-- Note: our per-project directory hasn't been created at this point so we can't write the file there.
+           Instead, save the merged file to the "conf" directory with a decorated name to make it unique. -->
+      <MergedRulesetFullName>$(SonarQubeRoslynRulesetFullName).$(MSBuildProjectName).$([System.DateTime]::Now.ToString("ffff"))</MergedRulesetFullName>
+    </PropertyGroup>
+
+    <MergeRuleSets Condition="$(RulesetMergeRequired) == 'true' "
                    PrimaryRulesetFilePath="$(SonarQubeRoslynRulesetFullName)"
                    IncludedRulesetFilePaths="$(ResolvedCodeAnalysisRuleSet)"
                    ProjectDirectoryPath="$(MSBuildProjectDirectory)"
+                   MergedRuleSetFilePath="$(MergedRulesetFullName)"
                    />
-   
+    
+    <PropertyGroup Condition="$(RulesetMergeRequired) == 'true' ">
+      <!-- Update the name of the ruleset to use -->
+      <SonarQubeRoslynRulesetFullName>$(MergedRulesetFullName)</SonarQubeRoslynRulesetFullName>
+    </PropertyGroup>
+    
+    
     <PropertyGroup Condition=" $(SonarLintFound) == 'true' ">
       <ErrorLog Condition=" $(ErrorLog) == '' " >$(TargetDir)SonarQube.Roslyn.ErrorLog.json</ErrorLog>
       <ResolvedCodeAnalysisRuleSet>$(SonarQubeRoslynRulesetFullName)</ResolvedCodeAnalysisRuleSet>

--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -472,7 +472,7 @@
       <!-- Calculate a unique name for the merged ruleset -->
       <!-- Note: our per-project directory hasn't been created at this point so we can't write the file there.
            Instead, save the merged file to the "conf" directory with a decorated name to make it unique. -->
-      <MergedRulesetFullName>$(SonarQubeRoslynRulesetFullName).$(MSBuildProjectName).$([System.DateTime]::Now.ToString("ffff"))</MergedRulesetFullName>
+      <MergedRulesetFullName>$(SonarQubeRoslynRulesetFullName).$(MSBuildProjectName).$([System.DateTime]::Now.ToString("fffff"))</MergedRulesetFullName>
     </PropertyGroup>
 
     <MergeRuleSets Condition="$(RulesetMergeRequired) == 'true' "

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -62,6 +62,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string SonarQubeExcludeMetadata = "SonarQubeExclude";
         public const string SonarQubeRulesetFormat = "SonarQubeFxCop-{0}.ruleset";
 
+        public const string MergedRulesetFullName = "MergedRulesetFullName";
+
         // Non-SonarQube constants
         public const string ProjectGuid = "ProjectGuid";
         public const string ProjectTypeGuids = "ProjectTypeGuids";
@@ -73,6 +75,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
         public const string AssemblyName = "AssemblyName";
 
         public const string IsInTeamBuild = "TF_Build"; // Common to legacy and non-legacy TeamBuilds
+        public const string ProjectName = "MSBuildProjectName";
 
         // Roslyn
         public const string ResolvedCodeAnalysisRuleset = "ResolvedCodeAnalysisRuleSet";


### PR DESCRIPTION
Added unit tests

Changed MergeRulesets and the targets so that the merged ruleset is created as a new file, rather than updating the shared, generated ruleset.
The merged ruleset will be created in the existing "conf" directory with the name *SonarQubeRoslyn-cs.ruleset.[ProjectName].[fffff]*, where *[fffff]* is a partial timestamp to help guarantee uniqueness.