### PR TITLE
[SONARMSBRU-198] Amended targets so warnings are not treated as errors

### DIFF
--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -364,6 +364,10 @@
       <CodeAnalysisForceOutput>true</CodeAnalysisForceOutput>
       <CodeAnalysisGenerateSuccessFile>true</CodeAnalysisGenerateSuccessFile>
       <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
+
+      <!-- Make sure no warnings are treated as errors -->
+      <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+      <WarningsAsErrors></WarningsAsErrors>
     </PropertyGroup>
 
   </Target>
@@ -427,11 +431,16 @@
         AfterTargets="ResolveCodeAnalysisRuleSet"
         BeforeTargets="CoreCompile">
 
-    <!-- Check whether to turn off code analysis -->
     <PropertyGroup>
+      <!-- Check whether to turn off code analysis logging -->
       <SonarQubeDisableRoslynCodeAnalysis Condition="$(SonarQubeExclude) == 'true' OR $(SonarQubeTestProject) == 'true' ">true</SonarQubeDisableRoslynCodeAnalysis>
+            
+      <!-- Make sure no warnings are treated as errors -->
+      <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+      <WarningsAsErrors></WarningsAsErrors>
     </PropertyGroup>
-    
+
+
     <PropertyGroup Condition=" $(SonarQubeDisableRoslynCodeAnalysis) == 'true' ">
       <ErrorLog></ErrorLog>
       <ResolvedCodeAnalysisRuleSet></ResolvedCodeAnalysisRuleSet>
@@ -439,7 +448,6 @@
     <!-- else -->
     <CallTarget Targets="SetRoslynCodeAnalysisProperties"
                 Condition="$(SonarQubeDisableRoslynCodeAnalysis) != 'true'"/>
-
   </Target>
 
   <Target Name="SetRoslynCodeAnalysisProperties">

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/E2ETests/E2EFxCopTests.cs
@@ -208,6 +208,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
             preImportProperties.CodeAnalysisRuleset = "specifiedInProject.ruleset";
 
+            preImportProperties.TreatWarningsAsErrors = "true"; // we expect these values to be overridden
+            preImportProperties.WarningsAsErrors = "CS0111;CS0222";
+
             preImportProperties[TargetProperties.SonarQubeConfigPath] = rootInputFolder;
             CreateValidFxCopRuleset(rootInputFolder, string.Format(TargetProperties.SonarQubeRulesetFormat, "cs"));
 
@@ -235,10 +238,10 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
 
             AssertAllFxCopTargetsExecuted(logger);
             Assert.IsTrue(File.Exists(fxCopLogFile), "FxCop log file should have been produced");
+            BuildAssertions.AssertWarningsAreNotTreatedAsErrors(result);
 
             ProjectInfo projectInfo = ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, projectRoot.FullPath);
             ProjectInfoAssertions.AssertAnalysisResultExists(projectInfo, AnalysisType.FxCop.ToString(), fxCopLogFile);
-
         }
 
         [TestMethod]
@@ -257,6 +260,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.E2E
             preImportProperties.RunCodeAnalysis = "false";
             preImportProperties.CodeAnalysisLogFile = fxCopLogFile;
             preImportProperties.CodeAnalysisRuleset = "specifiedInProject.ruleset";
+
+            preImportProperties.TreatWarningsAsErrors = "true"; // we expect these values to be overridden
+            preImportProperties.WarningsAsErrors = "VB0111;VB0222";
 
             preImportProperties[TargetProperties.SonarQubeConfigPath] = rootInputFolder;
             CreateValidFxCopRuleset(rootInputFolder, string.Format(TargetProperties.SonarQubeRulesetFormat, "vbnet"));
@@ -294,6 +300,7 @@ End Class");
 
             AssertAllFxCopTargetsExecuted(logger);
             Assert.IsTrue(File.Exists(fxCopLogFile), "FxCop log file should have been produced");
+            BuildAssertions.AssertWarningsAreNotTreatedAsErrors(result);
 
             ProjectInfo projectInfo = ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, projectRoot.FullPath);
             ProjectInfoAssertions.AssertAnalysisResultExists(projectInfo, AnalysisType.FxCop.ToString(), fxCopLogFile);

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
@@ -166,6 +166,15 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
             Assert.AreEqual(expectedCount, matches.Count(), "Unexpected number of '{0}' items", itemType);
         }
 
+        /// <summary>
+        /// Checks that no analysis warnings will be treated as errors
+        /// </summary>
+        public static void AssertWarningsAreNotTreatedAsErrors(BuildResult actualResult)
+        {
+            AssertExpectedPropertyValue(actualResult.ProjectStateAfterBuild, TargetProperties.TreatWarningsAsErrors, "false");
+            AssertExpectedPropertyValue(actualResult.ProjectStateAfterBuild, TargetProperties.WarningsAsErrors, "");
+        }
+
         #endregion
 
         #region Private methods

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -74,6 +74,9 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
 
         public const string AssemblyName = "AssemblyName";
 
+        public const string TreatWarningsAsErrors = "TreatWarningsAsErrors";
+        public const string WarningsAsErrors = "WarningsAsErrors";
+
         public const string IsInTeamBuild = "TF_Build"; // Common to legacy and non-legacy TeamBuilds
         public const string ProjectName = "MSBuildProjectName";
 

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/WellKnownProjectProperties.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/Infrastructure/WellKnownProjectProperties.cs
@@ -76,6 +76,18 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests
             set { this[TargetProperties.ErrorLog] = value; }
         }
 
+        public string WarningsAsErrors
+        {
+            get { return this.GetValueOrNull(TargetProperties.WarningsAsErrors); }
+            set { this[TargetProperties.WarningsAsErrors] = value; }
+        }
+
+        public string TreatWarningsAsErrors
+        {
+            get { return this.GetValueOrNull(TargetProperties.TreatWarningsAsErrors); }
+            set { this[TargetProperties.TreatWarningsAsErrors] = value; }
+        }
+
         public string AssemblyName
         {
             get { return this.GetValueOrNull(TargetProperties.AssemblyName); }

--- a/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarQube.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -53,6 +53,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             string expectedErrorLog = Path.Combine(targetDir, ErrorLogFileName);
             AssertExpectedAnalysisProperties(result, expectedErrorLog, GetDummyRulesetFilePath(), GetDummySonarLintXmlFilePath());
             AssertExpectedItemValuesExists(result, TargetProperties.AnalyzerItemType, GetSonarLintAnalyzerFilePaths());
+
+            BuildAssertions.AssertWarningsAreNotTreatedAsErrors(result);
         }
 
         [TestMethod]
@@ -89,6 +91,7 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
 
             AssertExpectedErrorLog(result, expectedErrorLog);
             AssertExpectedAdditionalFiles(result, GetDummySonarLintXmlFilePath());
+            BuildAssertions.AssertWarningsAreNotTreatedAsErrors(result);
 
             string mergedRulesetFilePath = AssertMergedResultFileExists(result, sourceRulesetFilePath);
             RuleSetAssertions.AssertExpectedIncludeFiles(mergedRulesetFilePath, "c:\\existing.ruleset");
@@ -126,6 +129,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             string sourceRulesetFilePath = GetDummyRulesetFilePath();
             this.TestContext.AddResultFile(sourceRulesetFilePath);
 
+            BuildAssertions.AssertWarningsAreNotTreatedAsErrors(result);
+
             string targetDir = result.ProjectStateAfterBuild.GetPropertyValue(TargetProperties.TargetDir);
             string expectedErrorLog = Path.Combine(targetDir, ErrorLogFileName);
 
@@ -147,6 +152,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             WellKnownProjectProperties properties = new WellKnownProjectProperties();
             properties.ErrorLog = "pre-existing.log";
             properties.ResolvedCodeAnalysisRuleset = "pre-existing.ruleset";
+            properties.WarningsAsErrors = "CS101";
+            properties.TreatWarningsAsErrors = "true";
 
             ProjectRootElement projectRoot = CreateValidProjectSetup(properties);
             projectRoot.AddProperty(TargetProperties.SonarQubeTempPath, string.Empty); // needs to overwritten once the valid project has been created
@@ -158,6 +165,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             logger.AssertTargetNotExecuted(TargetConstants.OverrideRoslynAnalysisTarget);
             logger.AssertTargetNotExecuted(TargetConstants.SetRoslynAnalysisPropertiesTarget);
             AssertExpectedAnalysisProperties(result, "pre-existing.log", "pre-existing.ruleset", string.Empty); // existing properties should not be changed
+            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.TreatWarningsAsErrors, "true");
+            BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, TargetProperties.WarningsAsErrors, "CS101");
         }
 
         [TestMethod]
@@ -185,6 +194,8 @@ namespace SonarQube.MSBuild.Tasks.IntegrationTests.TargetsTests
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarQubeRoslynRulesetExists", "False");
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarQubeRoslynAssemblyExists", "True");
             BuildAssertions.AssertExpectedPropertyValue(result.ProjectStateAfterBuild, "SonarLintFound", "false");
+
+            BuildAssertions.AssertWarningsAreNotTreatedAsErrors(result); // still expect warnings not to be treated as errors as that will fail the build
 
             AssertExpectedAnalysisProperties(result, "pre-existing.log", "pre-existing.ruleset", string.Empty);
         }


### PR DESCRIPTION
... for FxCop and Roslyn analysis
Updated tests

There is also a related StyleCop property *$(StyleCopTreatErrorsAsWarnings)*. However, we don't run StyleCop as part of the build (it's run by the StyleCop plugin in the sonar-runner) so there's no point in us setting that property in the targets file.