### PR TITLE
[SONARMSBRU-204] Added support for extracting ruleset from new Roslyn export XML

### DIFF
--- a/SonarQube.TeamBuild.PreProcessor/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Resources.Designer.cs
@@ -353,6 +353,15 @@ namespace SonarQube.TeamBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The exported profile does not contain a ruleset.
+        /// </summary>
+        public static string SLAP_ProfileDoesNotContainRuleset {
+            get {
+                return ResourceManager.GetString("SLAP_ProfileDoesNotContainRuleset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Found SonarLint profile export &apos;{0}&apos; for project &apos;{1}&apos;.
         /// </summary>
         public static string SLAP_ProfileExportFound {
@@ -385,6 +394,15 @@ namespace SonarQube.TeamBuild.PreProcessor {
         public static string SLAP_SonarLintRulesetCreated {
             get {
                 return ResourceManager.GetString("SLAP_SonarLintRulesetCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unpacking generated ruleset to {0}.
+        /// </summary>
+        public static string SLAP_UnpackingRuleset {
+            get {
+                return ResourceManager.GetString("SLAP_UnpackingRuleset", resourceCulture);
             }
         }
         

--- a/SonarQube.TeamBuild.PreProcessor/Resources.resx
+++ b/SonarQube.TeamBuild.PreProcessor/Resources.resx
@@ -217,6 +217,9 @@ The full path to a settings file can also be supplied. If it is not supplied, th
   <data name="SLAP_NoProfileForProject" xml:space="preserve">
     <value>Could not obtain a C# profile for project '{0}'</value>
   </data>
+  <data name="SLAP_ProfileDoesNotContainRuleset" xml:space="preserve">
+    <value>The exported profile does not contain a ruleset</value>
+  </data>
   <data name="SLAP_ProfileExportFound" xml:space="preserve">
     <value>Found SonarLint profile export '{0}' for project '{1}'</value>
   </data>
@@ -228,6 +231,9 @@ The full path to a settings file can also be supplied. If it is not supplied, th
   </data>
   <data name="SLAP_SonarLintRulesetCreated" xml:space="preserve">
     <value>SonarLint ruleset downloaded: {0}</value>
+  </data>
+  <data name="SLAP_UnpackingRuleset" xml:space="preserve">
+    <value>Unpacking generated ruleset to {0}</value>
   </data>
   <data name="WARN_ExistingGlobalTargets" xml:space="preserve">
     <value>This version of the SonarQube Scanner for MSBuild automatically deploys {0}, however a copy has been found in {1}. Please remove it if it is not intentional.</value>

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/CompilerAnalyzerConfig.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/CompilerAnalyzerConfig.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="CompilerAnalyzerConfig.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    /// <summary>
+    /// Data class containing the information required to configure
+    /// the compiler for Roslyn analysis
+    /// </summary>
+    public class CompilerAnalyzerConfig
+    {
+        private readonly string ruleSetFilePath;
+        private readonly IEnumerable<string> assemblyPaths;
+        private readonly IEnumerable<string> additionalFilePaths;
+
+        public CompilerAnalyzerConfig(string ruleSetFilePath, IEnumerable<string> analyzerAssemblies, IEnumerable<string> additionalFiles)
+        {
+            this.ruleSetFilePath = ruleSetFilePath;
+            this.assemblyPaths = analyzerAssemblies;
+            this.additionalFilePaths = additionalFiles;
+        }
+
+        /// <summary>
+        /// Path to the ruleset for the Roslyn analyzers
+        /// </summary>
+        public string RulesetFilePath { get { return this.ruleSetFilePath; } }
+
+        /// <summary>
+        /// File paths for all of the assemblies to pass to the compiler as analyzers
+        /// </summary>
+        /// <remarks>This includes analyzer assemblies and their dependencies</remarks>
+        public IEnumerable<string> AnalyzerAssemblyPaths { get { return this.assemblyPaths; } }
+
+        /// <summary>
+        /// File paths for all files to pass as "AdditionalFiles" to the compiler
+        /// </summary>
+        public IEnumerable<string> AdditionalFilePaths { get { return this.additionalFilePaths; } }
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/CompilerAnalyzerConfig.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/CompilerAnalyzerConfig.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace SonarQube.TeamBuild.PreProcessor.Roslyn
 {
@@ -21,9 +23,22 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn
 
         public CompilerAnalyzerConfig(string ruleSetFilePath, IEnumerable<string> analyzerAssemblies, IEnumerable<string> additionalFiles)
         {
+            if (string.IsNullOrWhiteSpace(ruleSetFilePath))
+            {
+                throw new ArgumentNullException("ruleSetFilePath");
+            }
+            if (analyzerAssemblies == null)
+            {
+                throw new ArgumentNullException("analyzerAssemblies");
+            }
+            if (additionalFiles == null)
+            {
+                throw new ArgumentNullException("additionalFiles");
+            }
+
             this.ruleSetFilePath = ruleSetFilePath;
-            this.assemblyPaths = analyzerAssemblies;
-            this.additionalFilePaths = additionalFiles;
+            this.assemblyPaths = analyzerAssemblies.ToArray();
+            this.additionalFilePaths = additionalFiles.ToArray();
         }
 
         /// <summary>

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/AdditionalFile.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/AdditionalFile.cs
@@ -1,0 +1,30 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AdditionalFile.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    /// <summary>
+    /// XML-serializable data class for a single analyzer AdditionalFile
+    /// </summary>
+    public class AdditionalFile
+    {
+        [XmlAttribute]
+        /// <summary>
+        /// The name of the file the content should be saved to
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// The content of the file
+        /// </summary>
+        [XmlAnyElement]
+        public XmlElement Content { get; set; }
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/AdditionalFile.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/AdditionalFile.cs
@@ -12,13 +12,14 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn
 {
     /// <summary>
     /// XML-serializable data class for a single analyzer AdditionalFile
+    /// i.e. the mechanism used by Roslyn to pass additional data to analyzers.
     /// </summary>
     public class AdditionalFile
     {
-        [XmlAttribute]
         /// <summary>
         /// The name of the file the content should be saved to
         /// </summary>
+        [XmlAttribute]
         public string FileName { get; set; }
 
         /// <summary>

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Configuration.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Configuration.cs
@@ -1,0 +1,25 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Configuration.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    /// <summary>
+    /// XML-serializable data class for Roslyn export configuration element
+    /// </summary>
+    public class Configuration
+    {
+        [XmlAnyElement("RuleSet")]
+        public XmlElement RuleSet { get; set; }
+
+        [XmlArray("AdditionalFiles")]
+        [XmlArrayItem("AdditionalFile")]
+        public List<AdditionalFile> AdditionalFiles { get; set; }
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Deployment.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/Deployment.cs
@@ -1,0 +1,18 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="Deployment.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    public class Deployment
+    {
+        [XmlArray("NuGetPackages")]
+        [XmlArrayItem(Type = typeof(NuGetPackageInfo), ElementName = "NuGetPackage")]
+        public List<NuGetPackageInfo> NuGetPackages { get; set; }
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/NuGetPackageInfo.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/NuGetPackageInfo.cs
@@ -1,0 +1,24 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="NuGetPackageInfo.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Xml.Serialization;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    /// <summary>
+    /// XML-serializable data class for a single NuGet package containing an analyzer
+    /// </summary>
+    public class NuGetPackageInfo
+    {
+        [XmlAttribute("Id")]
+        public string Id { get; set; }
+
+        [XmlAttribute("Version")]
+        public string Version { get; set; }
+
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/RoslynExportProfile.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/Model/RoslynExportProfile.cs
@@ -1,0 +1,72 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynExportProfile.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+using SonarQube.Common;
+using System;
+using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    /// <summary>
+    /// XML-serializable data class for Roslyn export profile information
+    /// </summary>
+    [XmlRoot]
+    public class RoslynExportProfile
+    {
+        [XmlAttribute]
+        public string Version { get; set; }
+
+        public Deployment Deployment { get; set; }
+
+        public Configuration Configuration { get; set; }
+
+        #region Serialization
+
+        [XmlIgnore]
+        public string FileName { get; private set; }
+
+        /// <summary>
+        /// Saves the project to the specified file as XML
+        /// </summary>
+        public void Save(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException("fileName");
+            }
+
+            Serializer.SaveModel(this, fileName);
+            this.FileName = fileName;
+        }
+
+        /// <summary>
+        /// Loads and returns project info from the specified XML file
+        /// </summary>
+        public static RoslynExportProfile Load(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException("fileName");
+            }
+
+            RoslynExportProfile model = Serializer.LoadModel<RoslynExportProfile>(fileName);
+            model.FileName = fileName;
+            return model;
+        }
+
+        public static RoslynExportProfile Load(TextReader reader)
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(RoslynExportProfile));
+            RoslynExportProfile profile = serializer.Deserialize(reader) as RoslynExportProfile;
+            return profile;
+        }
+
+        #endregion
+    }
+
+}

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -135,9 +135,11 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn
 
             IEnumerable<string> additionalFiles = this.UnpackAdditionalFiles(profile);
 
-            IEnumerable<string> analyzersAssemblies = FetchAnalyzerAssemblies(profile);
+            IEnumerable<string> analyzersAssemblies = this.FetchAnalyzerAssemblies(profile);
 
-            CompilerAnalyzerConfig compilerConfig = new CompilerAnalyzerConfig(rulesetFilePath, analyzersAssemblies, additionalFiles);
+            CompilerAnalyzerConfig compilerConfig = new CompilerAnalyzerConfig(rulesetFilePath,
+                analyzersAssemblies ?? Enumerable.Empty<string>(),
+                additionalFiles ?? Enumerable.Empty<string>());
             return compilerConfig;
         }
 

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -1,0 +1,167 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynAnalyzerProvider.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using SonarQube.Common;
+using SonarQube.TeamBuild.Integration;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace SonarQube.TeamBuild.PreProcessor.Roslyn
+{
+    public class RoslynAnalyzerProvider
+    {
+        public const string RoslynCSharpFormatName = "roslyn-config-cs";
+
+        public const string CSharpLanguage = "cs";
+        public const string CSharpPluginKey = "csharp";
+
+        private readonly ISonarQubeServer server;
+        private readonly TeamBuildSettings settings;
+        private readonly string projectKey;
+        private readonly ILogger logger;
+
+        #region Public methods
+
+        /// Sets up the client to run the Roslyn analyzers as part of the build
+        /// i.e. creates the Roslyn ruleset and provisions the analyzer assemblies
+        /// and rule parameter files
+        /// </summary>
+        public static CompilerAnalyzerConfig SetupAnalyzers(ISonarQubeServer server, TeamBuildSettings settings, string projectKey, ILogger logger)
+        {
+            if (server == null)
+            {
+                throw new ArgumentNullException("server");
+            }
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (string.IsNullOrWhiteSpace(projectKey))
+            {
+                throw new ArgumentNullException("projectKey");
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
+            }
+
+            if (IsCSharpPluginInstalled(server))
+            {
+                RoslynAnalyzerProvider provider = new RoslynAnalyzerProvider(server, settings, projectKey, logger);
+                return provider.GetCompilerConfig();
+            }
+            else
+            {
+                logger.LogDebug(Resources.SLAP_CSharpPluginNotInstalled);
+            }
+
+            return null;
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private static bool IsCSharpPluginInstalled(ISonarQubeServer server)
+        {
+            return server.GetInstalledPlugins().Contains(CSharpPluginKey);
+        }
+
+        private RoslynAnalyzerProvider(ISonarQubeServer server, TeamBuildSettings settings, string projectKey, ILogger logger)
+        {
+            this.server = server;
+            this.settings = settings;
+            this.projectKey = projectKey;
+            this.logger = logger;
+        }
+
+        private CompilerAnalyzerConfig GetCompilerConfig()
+        {
+            CompilerAnalyzerConfig compilerConfig = null;
+
+            RoslynExportProfile profile = TryGetRoslynConfigForProject();
+            if (profile != null)
+            {
+                compilerConfig = ProcessProfile(profile);
+            }
+            return compilerConfig;
+        }
+
+        private RoslynExportProfile TryGetRoslynConfigForProject()
+        {
+            string qualityProfile;
+            if (!this.server.TryGetQualityProfile(projectKey, CSharpLanguage, out qualityProfile))
+            {
+                this.logger.LogDebug(Resources.SLAP_NoProfileForProject, this.projectKey);
+                return null;
+            }
+
+            string profileContent = null;
+            if (!server.TryGetProfileExport(qualityProfile, CSharpLanguage, RoslynCSharpFormatName, out profileContent))
+            {
+                this.logger.LogDebug(Resources.SLAP_ProfileExportNotFound, RoslynCSharpFormatName, this.projectKey);
+                return null;
+            }
+            this.logger.LogDebug(Resources.SLAP_ProfileExportFound, RoslynCSharpFormatName, this.projectKey);
+
+            RoslynExportProfile profile = null;
+            using (StringReader reader = new StringReader(profileContent))
+            {
+                profile = RoslynExportProfile.Load(reader);
+            }
+
+            return profile;
+        }
+
+        private CompilerAnalyzerConfig ProcessProfile(RoslynExportProfile profile)
+        {
+            Debug.Assert(profile != null, "Expecting a valid profile");
+
+            string rulesetFilePath = this.UnpackRuleset(profile);
+
+            IEnumerable<string> additionalFiles = this.UnpackAdditionalFiles(profile);
+
+            IEnumerable<string> analyzersAssemblies = FetchAnalyzerAssemblies(profile);
+
+            CompilerAnalyzerConfig compilerConfig = new CompilerAnalyzerConfig(rulesetFilePath, analyzersAssemblies, additionalFiles);
+            return compilerConfig;
+        }
+
+        private string UnpackRuleset(RoslynExportProfile profile)
+        {
+            // TODO
+            return null;
+        }
+
+        private IEnumerable<string> UnpackAdditionalFiles(RoslynExportProfile profile)
+        {
+            // TODO
+            return null;
+        }
+
+        private IEnumerable<string> FetchAnalyzerAssemblies(RoslynExportProfile profile)
+        {
+            // TODO
+            if (profile.Deployment != null && profile.Deployment.NuGetPackages != null)
+            {
+                foreach (NuGetPackageInfo p in profile.Deployment.NuGetPackages)
+                {
+                    // TODO: Fetch NuGet package
+                }
+            }
+            return null;
+        }
+
+
+
+        #endregion
+    }
+}

--- a/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
+++ b/SonarQube.TeamBuild.PreProcessor/SonarQube.TeamBuild.PreProcessor.csproj
@@ -58,6 +58,13 @@
     <Compile Include="Interfaces\ISonarQubeServerFactory.cs" />
     <Compile Include="Interfaces\ITargetsInstaller.cs" />
     <Compile Include="Interfaces\ISonarQubeServer.cs" />
+    <Compile Include="Roslyn\Model\AdditionalFile.cs" />
+    <Compile Include="Roslyn\CompilerAnalyzerConfig.cs" />
+    <Compile Include="Roslyn\Model\Configuration.cs" />
+    <Compile Include="Roslyn\Model\Deployment.cs" />
+    <Compile Include="Roslyn\Model\NuGetPackageInfo.cs" />
+    <Compile Include="Roslyn\Model\RoslynExportProfile.cs" />
+    <Compile Include="Roslyn\RoslynAnalyzerProvider.cs" />
     <Compile Include="SonarLintAnalyzerProvider.cs" />
     <Compile Include="SonarQubeServerFactory.cs" />
     <Compile Include="ProcessedArgs.cs" />

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
@@ -1,0 +1,260 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynAnalyzerProviderTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.TeamBuild.Integration;
+using SonarQube.TeamBuild.PreProcessor.Roslyn;
+using System.IO;
+using TestUtilities;
+
+namespace SonarQube.TeamBuild.PreProcessor.Tests
+{
+    [TestClass]
+    public class RoslynAnalyzerProviderTests
+    {
+        public TestContext TestContext { get; set; }
+
+        #region Tests
+
+        [TestMethod]
+        public void RoslynConfig_PluginNotInstalled()
+        {
+            // Arrange
+            string rootDir = CreateTestFolders();
+            TestLogger logger = new TestLogger();
+            TeamBuildSettings settings = CreateSettings(rootDir);
+
+            MockSonarQubeServer mockServer = CreateValidServer("valid.project", "valid.profile");
+            mockServer.Data.InstalledPlugins.Remove(RoslynAnalyzerProvider.CSharpPluginKey);
+
+            // Act
+            CompilerAnalyzerConfig actualConfig = RoslynAnalyzerProvider.SetupAnalyzers(mockServer, settings, "valid.project", logger);
+
+            // Assert
+            AssertAnalyzerConfigNotPerformed(actualConfig, rootDir);
+
+            logger.AssertErrorsLogged(0);
+        }
+
+        [TestMethod]
+        public void RoslynConfig_ProjectNotInProfile()
+        {
+            // Arrange
+            string rootDir = CreateTestFolders();
+            TestLogger logger = new TestLogger();
+            TeamBuildSettings settings = CreateSettings(rootDir);
+
+            MockSonarQubeServer mockServer = CreateValidServer("valid.project", "valid.profile");
+
+            // Act
+            CompilerAnalyzerConfig actualConfig = RoslynAnalyzerProvider.SetupAnalyzers(mockServer, settings, "unknown.project", logger);
+
+            // Assert
+            AssertAnalyzerConfigNotPerformed(actualConfig, rootDir);
+
+            logger.AssertErrorsLogged(0);
+        }
+
+
+        [TestMethod]
+        public void RoslynConfig_MissingRuleset()
+        {
+            // Arrange
+            string rootDir = CreateTestFolders();
+            TestLogger logger = new TestLogger();
+            TeamBuildSettings settings = CreateSettings(rootDir);
+
+            MockSonarQubeServer mockServer = CreateValidServer("valid.project", "valid.profile");
+            QualityProfile csProfile = mockServer.Data.FindProfile("valid.profile", RoslynAnalyzerProvider.CSharpLanguage);
+            csProfile.SetExport(RoslynAnalyzerProvider.RoslynCSharpFormatName, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<RoslynExportProfile Version=""1.0="">
+  <Configuration>
+    <!-- Missing ruleset -->
+    <AdditionalFiles>
+      <AdditionalFile FileName=""SonarLint.xml"" >
+      </AdditionalFile>
+    </AdditionalFiles>
+  </Configuration>
+  <Deployment>
+    <NuGetPackages>
+      <Package Id=""SonarLint"" Version=""1.3.0""/>
+    </NuGetPackages>
+  </Deployment>
+</RoslynExportProfile>");
+
+            // Act
+            CompilerAnalyzerConfig actualConfig = RoslynAnalyzerProvider.SetupAnalyzers(mockServer, settings, "valid.project", logger);
+
+            // Assert
+            AssertAnalyzerConfigNotPerformed(actualConfig, rootDir);
+
+            logger.AssertErrorsLogged(0);
+        }
+
+        [TestMethod]
+        public void RoslynConfig_ValidProfile()
+        {
+            // Arrange
+            string rootDir = CreateTestFolders();
+            TestLogger logger = new TestLogger();
+            TeamBuildSettings settings = CreateSettings(rootDir);
+            MockSonarQubeServer mockServer = CreateValidServer("valid.project", "valid.profile");
+
+            // Act
+            CompilerAnalyzerConfig actualConfig = RoslynAnalyzerProvider.SetupAnalyzers(mockServer, settings, "valid.project", logger);
+
+            // Assert
+            Assert.IsNotNull(actualConfig);
+
+            CheckRulesetExists(actualConfig, rootDir);
+        }
+
+        #endregion
+
+
+        #region Private methods
+
+        private string CreateTestFolders()
+        {
+            string rootFolder = TestUtils.CreateTestSpecificFolder(this.TestContext);
+
+            // Create the binary and conf folders that are created by the bootstrapper
+            Directory.CreateDirectory(GetBinaryPath(rootFolder));
+            Directory.CreateDirectory(GetConfPath(rootFolder));
+
+            return rootFolder;
+        }
+
+        /// <summary>
+        /// Creates and returns a mock server that is correctly configured to return
+        /// a Roslyn ruleset for the specified project key and profile
+        /// </summary>
+        private MockSonarQubeServer CreateValidServer(string validProjectKey, string validProfileName)
+        {
+            ServerDataModel model = new ServerDataModel();
+            model.InstalledPlugins.Add(RoslynAnalyzerProvider.CSharpPluginKey);
+            model.InstalledPlugins.Add("unused");
+
+            model.AddQualityProfile(validProfileName, "vb")
+                .AddProject(validProjectKey)
+                .AddProject(validProfileName);
+
+            model.AddQualityProfile(validProfileName, RoslynAnalyzerProvider.CSharpLanguage)
+                .AddProject(validProjectKey)
+                .AddProject("project3")
+                .SetExport(RoslynAnalyzerProvider.RoslynCSharpFormatName, GetValidCSharpProfile());
+
+            model.AddRepository(RoslynAnalyzerProvider.CSharpRepositoryKey, RoslynAnalyzerProvider.CSharpLanguage);
+
+            MockSonarQubeServer server = new MockSonarQubeServer();
+            server.Data = model;
+            return server;
+        }
+
+        private static string GetValidCSharpProfile()
+        {
+            return @"<?xml version=""1.0"" encoding=""utf-8""?>
+<RoslynExportProfile Version=""1.0="">
+  <Configuration>
+    <RuleSet Name=""Rules for SonarQube"" Description=""This rule set was automatically generated from SonarQube."" ToolsVersion=""14.0"">
+      <Rules AnalyzerId=""SonarLint.CSharp"" RuleNamespace=""SonarLint.CSharp"">
+        <Rule Id=""S1116"" Action=""Warning"" />
+        <Rule Id=""S1125"" Action=""Warning"" />
+        <!-- other rules omitted -->
+      </Rules>
+      <Rules AnalyzerId=""Wintellect.Analyzers"" RuleNamespace=""Wintellect.Analyzers"">
+        <Rule Id=""Wintellect003"" Action=""Warning"" />
+        <!-- other rules omitted -->
+      </Rules>
+    </RuleSet>
+    <AdditionalFiles>
+      <AdditionalFile FileName=""SonarLint.xml"" >
+        <AnalysisInput>
+          <Rules>
+            <Rule>
+              <Key>S1067</Key>
+              <Parameters>
+                <Parameter>
+                  <Key>max</Key>
+                  <Value>3</Value>
+                </Parameter>
+              </Parameters>
+            </Rule>
+          </Rules>
+          <Files>
+          </Files>
+        </AnalysisInput>
+      </AdditionalFile>
+      <AdditionalFile FileName=""MyAnalyzerData.xml"" >
+        <Foo />
+      </AdditionalFile>
+    </AdditionalFiles>
+  </Configuration>
+
+  <Deployment>
+    <NuGetPackages>
+      <Package Id=""SonarLint"" Version=""1.3.0"" />
+      <Package Id=""Wintellect.Analyzers"" Version=""1.0.5.0-rc1"" />
+    </NuGetPackages>
+  </Deployment>
+</RoslynExportProfile>";
+        }
+
+        private static TeamBuildSettings CreateSettings(string rootDir)
+        {
+            TeamBuildSettings settings = TeamBuildSettings.CreateNonTeamBuildSettingsForTesting(rootDir);
+            return settings;
+        }
+
+        private static string GetExpectedRulesetFileName(string rootDir)
+        {
+            return Path.Combine(GetConfPath(rootDir), RoslynAnalyzerProvider.RoslynCSharpRulesetFileName);
+        }
+
+        private static string GetConfPath(string rootDir)
+        {
+            return Path.Combine(rootDir, "conf");
+        }
+
+        private static string GetBinaryPath(string rootDir)
+        {
+            return Path.Combine(rootDir, "bin");
+        }
+
+        #endregion
+
+        #region Checks
+
+        private void CheckRulesetExists(CompilerAnalyzerConfig actualConfig, string rootTestDir)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(actualConfig.RulesetFilePath), "Ruleset file path should be set");
+            Assert.IsTrue(Path.IsPathRooted(actualConfig.RulesetFilePath), "Ruleset file path should be absolute");
+            Assert.IsTrue(File.Exists(actualConfig.RulesetFilePath), "Expected ruleset file does not exist: {0}", actualConfig.RulesetFilePath);
+            this.TestContext.AddResultFile(actualConfig.RulesetFilePath);
+
+            Assert.AreEqual(RoslynAnalyzerProvider.RoslynCSharpRulesetFileName, Path.GetFileName(actualConfig.RulesetFilePath), "Ruleset file does not have the expected name");
+
+            string expectedFilePath = GetExpectedRulesetFileName(rootTestDir);
+            Assert.AreEqual(expectedFilePath, actualConfig.RulesetFilePath, "Ruleset was not written to the expected location");
+        }
+
+        private static void CheckRulesetDoesNotExist(string rootTestDir)
+        {
+            string filePath = GetExpectedRulesetFileName(rootTestDir);
+            Assert.IsFalse(File.Exists(filePath), "Not expecting the ruleset file to exist: {0}", filePath);
+        }
+
+        private static void AssertAnalyzerConfigNotPerformed(CompilerAnalyzerConfig actual, string rootTestDir)
+        {
+            Assert.IsNull(actual, "Not expecting a config instance to have been returned");
+            CheckRulesetDoesNotExist(rootTestDir);
+        }
+
+        #endregion
+
+    }
+}

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/RoslynExportProfileTests.cs
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/RoslynExportProfileTests.cs
@@ -1,0 +1,95 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RoslynExportProfileTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.TeamBuild.PreProcessor.Roslyn;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace SonarQube.TeamBuild.PreProcessor.Tests
+{
+    [TestClass]
+    public class RoslynExportProfileTests
+    {
+        public TestContext TestContext { get; set; }
+
+        #region Tests
+
+        [TestMethod]
+        public void RoslynProfile_LoadValidProfile_Succeeds()
+        {
+            string validXml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<RoslynExportProfile Version=""1.0"">
+  <Configuration>
+    <RuleSet Name=""Rules for SonarQube"" Description=""This rule set was automatically generated from SonarQube."" ToolsVersion=""14.0"">
+      <Rules>
+        <Rule Id=""Foo""/>
+      </Rules>
+    </RuleSet>
+
+    <AdditionalFiles>
+      <AdditionalFile FileName=""SonarLint.xml"" >
+         <AnalysisInput />
+      </AdditionalFile>
+      <AdditionalFile FileName=""MyAnalyzer.xml"" >
+         <Foo />
+      </AdditionalFile>
+    </AdditionalFiles>
+  </Configuration>
+
+  <Deployment>
+    <NuGetPackages>
+      <NuGetPackage Id=""SonarLint"" Version=""1.3.0""/>
+      <NuGetPackage Id=""My.Analyzers"" Version=""1.0.5.0""/>
+    </NuGetPackages>
+  </Deployment>
+</RoslynExportProfile>";
+
+            RoslynExportProfile profile = null;
+            using (StringReader reader = new StringReader(validXml))
+            {
+                profile = RoslynExportProfile.Load(reader);
+            }
+
+            Assert.IsNotNull(profile);
+            Assert.IsNotNull(profile.Configuration);
+            Assert.IsNotNull(profile.Configuration.RuleSet);
+
+            AssertExpectedAdditionalFileExists("SonarLint.xml", profile);
+            AssertExpectedAdditionalFileExists("MyAnalyzer.xml", profile);
+
+            AssertExpectedPackageExists("SonarLint", "1.3.0", profile);
+            AssertExpectedPackageExists("My.Analyzers", "1.0.5.0", profile);
+
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private static void AssertExpectedAdditionalFileExists(string fileName, RoslynExportProfile profile)
+        {
+            Assert.IsNotNull(profile.Configuration.AdditionalFiles);
+            IEnumerable<AdditionalFile> matches = profile.Configuration.AdditionalFiles.Where(f => string.Equals(fileName, f.FileName, System.StringComparison.OrdinalIgnoreCase));
+            Assert.AreNotEqual(0, matches.Count(), "Expected additional file was not found. File name: {0}", fileName);
+            Assert.AreEqual(1, matches.Count(), "Expecting only one matching file. File name: {0}", fileName);
+            Assert.IsNotNull(matches.First().Content, "File content should not be null. File name: {0}", fileName);
+        }
+
+        private static void AssertExpectedPackageExists(string packageId, string version, RoslynExportProfile profile)
+        {
+            Assert.IsNotNull(profile.Deployment);
+            IEnumerable<NuGetPackageInfo> matches = profile.Deployment.NuGetPackages.Where(
+                p => string.Equals(packageId, p.Id, System.StringComparison.Ordinal) &&
+                        string.Equals(version, p.Version, System.StringComparison.Ordinal));
+            Assert.AreNotEqual(0, matches.Count(), "Expected package was not found. Package: {0}, Version: {1}", packageId, version);
+            Assert.AreEqual(1, matches.Count(), "Expecting only one matching package. Package: {0}, Version: {1}", packageId, version);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/SonarQube.TeamBuild.PreProcessor.Tests.csproj
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/SonarQube.TeamBuild.PreProcessor.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Infrastructure\PreprocessTestUtils.cs" />
     <Compile Include="ProcessedArgsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RoslynAnalyzerProviderTests.cs" />
     <Compile Include="RoslynExportProfileTests.cs" />
     <Compile Include="RulesetGeneratorTests.cs" />
     <Compile Include="RulesetWriterTest.cs" />

--- a/Tests/SonarQube.TeamBuild.PreProcessor.Tests/SonarQube.TeamBuild.PreProcessor.Tests.csproj
+++ b/Tests/SonarQube.TeamBuild.PreProcessor.Tests/SonarQube.TeamBuild.PreProcessor.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Infrastructure\PreprocessTestUtils.cs" />
     <Compile Include="ProcessedArgsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RoslynExportProfileTests.cs" />
     <Compile Include="RulesetGeneratorTests.cs" />
     <Compile Include="RulesetWriterTest.cs" />
     <Compile Include="DataModel\QualityProfile.cs" />


### PR DESCRIPTION
Added serialization model and tests to load the new XML profile format
Created a RoslynAnalyzerProvider (similar to the existing SonarLintAnalyzerProvider, which will be redundant once the RoslynAnalyzerProvider is finished). Currently the new provider fetches the profile and extracts the ruleset.
TODO: extract the analyser rule config files
TODO: amend the target files
Fetching the NuGet packages is part of [SONARMSBRU-205]
